### PR TITLE
Remove unneeded test

### DIFF
--- a/OsmAnd-java/src/net/osmand/plus/voice/AbstractPrologCommandPlayer.java
+++ b/OsmAnd-java/src/net/osmand/plus/voice/AbstractPrologCommandPlayer.java
@@ -106,12 +106,9 @@ public abstract class AbstractPrologCommandPlayer implements CommandPlayer {
 				// } else {
 				config = new FileInputStream(new File(voiceDir, configFile)); //$NON-NLS-1$
 				// }
-				if (!wrong) {
-					MetricsConstants mc = settings.METRIC_SYSTEM.get();
-					prologSystem.addTheory(new Theory("measure('"+mc.toTTSString()+"')."));
-					prologSystem.addTheory(new Theory(config));
-					
-				}
+				MetricsConstants mc = settings.METRIC_SYSTEM.get();
+				prologSystem.addTheory(new Theory("measure('"+mc.toTTSString()+"')."));
+				prologSystem.addTheory(new Theory(config));
 			} catch (InvalidTheoryException e) {
 				log.error("Loading voice config exception " + voiceProvider, e); //$NON-NLS-1$
 				wrong = true;


### PR DESCRIPTION
Correct me if I am wrong, but since wrong is false (defined at [line 100](https://github.com/osmandapp/OsmAnd-core/blob/master/OsmAnd-java/src/net/osmand/plus/voice/AbstractPrologCommandPlayer.java#L100)) it's not necessary to test for it at [line 109](https://github.com/osmandapp/OsmAnd-core/blob/master/OsmAnd-java/src/net/osmand/plus/voice/AbstractPrologCommandPlayer.java#L109) (since it will only be true after the if).
