### PR TITLE
Add highway=platform for pedestrian

### DIFF
--- a/embeddable-resources/routing.xml
+++ b/embeddable-resources/routing.xml
@@ -568,6 +568,7 @@
 			<select value="1" t="highway" v="pedestrian"/>
 			<select value="1" t="highway" v="footway"/>
 			<select value="1" t="highway" v="byway"/>
+			<select value="1" t="highway" v="platform"/>
 			<select value="1" t="highway" v="services"/>
 			<select value="1" t="highway" v="bridleway"/>
 			<select value="1" t="highway" v="steps"/>


### PR DESCRIPTION
Modern public transport tagging uses highway=platform. Pedestrians can use them to get to/from bus stops for example. So we should simply add them to the list of roads we can take.
