### PR TITLE
Use more stable URL for zlib download (sf.net).

### DIFF
--- a/externals/zlib/configure.sh
+++ b/externals/zlib/configure.sh
@@ -16,7 +16,7 @@ fi
 
 # Download
 echo "Zlib Downloading new upstream..."
-curl -L http://zlib.net/zlib-1.2.7.tar.bz2 > $SRCLOC/upstream.tar.bz2 || { echo "Failed to download!" 1>&2; exit; }
+curl -L http://sourceforge.net/projects/libpng/files/zlib/1.2.7/zlib-1.2.7.tar.bz2/download > $SRCLOC/upstream.tar.bz2 || { echo "Failed to download!" 1>&2; exit; }
 
 # Extract
 echo "Zlib Extracting upstream..."


### PR DESCRIPTION
Apparently, zlib.net hosts only the latest version. New URL comes from link
published on zlib.net page.
