### PR TITLE
Precision of POI for iOS

### DIFF
--- a/include/OsmAndCore/Utilities.h
+++ b/include/OsmAndCore/Utilities.h
@@ -887,7 +887,8 @@ namespace OsmAnd
 
         static QString resolveColorFromPalette(const QString& input, const bool usePalette6);
         static LatLon rhumbDestinationPoint(LatLon latLon, double distance, double bearing);
-
+        static std::pair<int, int> calculateFinalXYFromBaseAndPrecisionXY(int bazeZoom, int finalZoom, int precisionXY,
+                                                                          int xBase, int yBase, bool ignoreNotEnoughPrecision);
     private:
         Utilities();
         ~Utilities();

--- a/protos/OBF.pb.cc
+++ b/protos/OBF.pb.cc
@@ -963,7 +963,7 @@ void protobuf_AssignDesc_OBF_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(OsmAndPoiBoxData));
   OsmAndPoiBoxDataAtom_descriptor_ = file->message_type(35);
-  static const int OsmAndPoiBoxDataAtom_offsets_[13] = {
+  static const int OsmAndPoiBoxDataAtom_offsets_[14] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(OsmAndPoiBoxDataAtom, dx_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(OsmAndPoiBoxDataAtom, dy_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(OsmAndPoiBoxDataAtom, categories_),
@@ -977,6 +977,7 @@ void protobuf_AssignDesc_OBF_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(OsmAndPoiBoxDataAtom, note_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(OsmAndPoiBoxDataAtom, textcategories_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(OsmAndPoiBoxDataAtom, textvalues_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(OsmAndPoiBoxDataAtom, precisionxy_),
   };
   OsmAndPoiBoxDataAtom_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -1497,37 +1498,38 @@ void protobuf_AddDesc_OBF_2eproto() {
     "tegories\030\003 \003(\r\022\025\n\rsubcategories\030\005 \003(\r\"i\n"
     "\020OsmAndPoiBoxData\022\014\n\004zoom\030\001 \001(\r\022\t\n\001x\030\002 \001"
     "(\r\022\t\n\001y\030\003 \001(\r\0221\n\007poiData\030\005 \003(\0132 .OsmAnd."
-    "OBF.OsmAndPoiBoxDataAtom\"\360\001\n\024OsmAndPoiBo"
+    "OBF.OsmAndPoiBoxDataAtom\"\205\002\n\024OsmAndPoiBo"
     "xDataAtom\022\n\n\002dx\030\002 \002(\021\022\n\n\002dy\030\003 \002(\021\022\022\n\ncat"
     "egories\030\004 \003(\r\022\025\n\rsubcategories\030\005 \003(\r\022\014\n\004"
     "name\030\006 \001(\t\022\016\n\006nameEn\030\007 \001(\t\022\n\n\002id\030\010 \001(\004\022\024"
     "\n\014openingHours\030\n \001(\t\022\014\n\004site\030\013 \001(\t\022\r\n\005ph"
     "one\030\014 \001(\t\022\014\n\004note\030\r \001(\t\022\026\n\016textCategorie"
-    "s\030\016 \003(\r\022\022\n\ntextValues\030\017 \003(\t\"\032\n\007IdTable\022\017"
-    "\n\007routeId\030\001 \003(\022\"F\n\017RestrictionData\022\014\n\004ty"
-    "pe\030\001 \002(\005\022\014\n\004from\030\002 \002(\005\022\n\n\002to\030\003 \002(\005\022\013\n\003vi"
-    "a\030\004 \001(\005\"x\n\tRouteData\022\016\n\006points\030\001 \002(\014\022\022\n\n"
-    "pointTypes\030\004 \001(\014\022\022\n\npointNames\030\005 \001(\014\022\r\n\005"
-    "types\030\007 \002(\014\022\017\n\007routeId\030\014 \002(\005\022\023\n\013stringNa"
-    "mes\030\016 \001(\014\"\304\005\n\022OsmAndRoutingIndex\022\014\n\004name"
-    "\030\001 \002(\t\022\?\n\005rules\030\002 \003(\01320.OsmAnd.OBF.OsmAn"
-    "dRoutingIndex.RouteEncodingRule\022>\n\trootB"
-    "oxes\030\003 \003(\0132+.OsmAnd.OBF.OsmAndRoutingInd"
-    "ex.RouteDataBox\022A\n\014basemapBoxes\030\004 \003(\0132+."
-    "OsmAnd.OBF.OsmAndRoutingIndex.RouteDataB"
-    "ox\022=\n\006blocks\030\005 \003(\0132-.OsmAnd.OBF.OsmAndRo"
-    "utingIndex.RouteDataBlock\032;\n\021RouteEncodi"
-    "ngRule\022\013\n\003tag\030\003 \002(\t\022\r\n\005value\030\005 \002(\t\022\n\n\002id"
-    "\030\007 \001(\r\032\231\001\n\014RouteDataBox\022\014\n\004left\030\001 \002(\021\022\r\n"
-    "\005right\030\002 \002(\021\022\013\n\003top\030\003 \002(\021\022\016\n\006bottom\030\004 \002("
-    "\021\022\023\n\013shiftToData\030\005 \001(\007\022:\n\005boxes\030\007 \003(\0132+."
-    "OsmAnd.OBF.OsmAndRoutingIndex.RouteDataB"
-    "ox\032\303\001\n\016RouteDataBlock\022$\n\007idTable\030\005 \001(\0132\023"
-    ".OsmAnd.OBF.IdTable\022*\n\013dataObjects\030\006 \003(\013"
-    "2\025.OsmAnd.OBF.RouteData\0221\n\014restrictions\030"
-    "\007 \003(\0132\033.OsmAnd.OBF.RestrictionData\022,\n\013st"
-    "ringTable\030\010 \001(\0132\027.OsmAnd.OBF.StringTable"
-    "B\036\n\021net.osmand.binaryB\tOsmandOdb", 7592);
+    "s\030\016 \003(\r\022\022\n\ntextValues\030\017 \003(\t\022\023\n\013precision"
+    "XY\030\020 \001(\005\"\032\n\007IdTable\022\017\n\007routeId\030\001 \003(\022\"F\n\017"
+    "RestrictionData\022\014\n\004type\030\001 \002(\005\022\014\n\004from\030\002 "
+    "\002(\005\022\n\n\002to\030\003 \002(\005\022\013\n\003via\030\004 \001(\005\"x\n\tRouteDat"
+    "a\022\016\n\006points\030\001 \002(\014\022\022\n\npointTypes\030\004 \001(\014\022\022\n"
+    "\npointNames\030\005 \001(\014\022\r\n\005types\030\007 \002(\014\022\017\n\007rout"
+    "eId\030\014 \002(\005\022\023\n\013stringNames\030\016 \001(\014\"\304\005\n\022OsmAn"
+    "dRoutingIndex\022\014\n\004name\030\001 \002(\t\022\?\n\005rules\030\002 \003"
+    "(\01320.OsmAnd.OBF.OsmAndRoutingIndex.Route"
+    "EncodingRule\022>\n\trootBoxes\030\003 \003(\0132+.OsmAnd"
+    ".OBF.OsmAndRoutingIndex.RouteDataBox\022A\n\014"
+    "basemapBoxes\030\004 \003(\0132+.OsmAnd.OBF.OsmAndRo"
+    "utingIndex.RouteDataBox\022=\n\006blocks\030\005 \003(\0132"
+    "-.OsmAnd.OBF.OsmAndRoutingIndex.RouteDat"
+    "aBlock\032;\n\021RouteEncodingRule\022\013\n\003tag\030\003 \002(\t"
+    "\022\r\n\005value\030\005 \002(\t\022\n\n\002id\030\007 \001(\r\032\231\001\n\014RouteDat"
+    "aBox\022\014\n\004left\030\001 \002(\021\022\r\n\005right\030\002 \002(\021\022\013\n\003top"
+    "\030\003 \002(\021\022\016\n\006bottom\030\004 \002(\021\022\023\n\013shiftToData\030\005 "
+    "\001(\007\022:\n\005boxes\030\007 \003(\0132+.OsmAnd.OBF.OsmAndRo"
+    "utingIndex.RouteDataBox\032\303\001\n\016RouteDataBlo"
+    "ck\022$\n\007idTable\030\005 \001(\0132\023.OsmAnd.OBF.IdTable"
+    "\022*\n\013dataObjects\030\006 \003(\0132\025.OsmAnd.OBF.Route"
+    "Data\0221\n\014restrictions\030\007 \003(\0132\033.OsmAnd.OBF."
+    "RestrictionData\022,\n\013stringTable\030\010 \001(\0132\027.O"
+    "smAnd.OBF.StringTableB\036\n\021net.osmand.bina"
+    "ryB\tOsmandOdb", 7613);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "OBF.proto", &protobuf_RegisterTypes);
   OsmAndStructure::default_instance_ = new OsmAndStructure();
@@ -17841,6 +17843,7 @@ const int OsmAndPoiBoxDataAtom::kPhoneFieldNumber;
 const int OsmAndPoiBoxDataAtom::kNoteFieldNumber;
 const int OsmAndPoiBoxDataAtom::kTextCategoriesFieldNumber;
 const int OsmAndPoiBoxDataAtom::kTextValuesFieldNumber;
+const int OsmAndPoiBoxDataAtom::kPrecisionXYFieldNumber;
 #endif  // !_MSC_VER
 
 OsmAndPoiBoxDataAtom::OsmAndPoiBoxDataAtom()
@@ -17868,6 +17871,7 @@ void OsmAndPoiBoxDataAtom::SharedCtor() {
   site_ = const_cast< ::std::string*>(&::google::protobuf::internal::kEmptyString);
   phone_ = const_cast< ::std::string*>(&::google::protobuf::internal::kEmptyString);
   note_ = const_cast< ::std::string*>(&::google::protobuf::internal::kEmptyString);
+  precisionxy_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -17956,6 +17960,7 @@ void OsmAndPoiBoxDataAtom::Clear() {
         note_->clear();
       }
     }
+    precisionxy_ = 0;
   }
   categories_.Clear();
   subcategories_.Clear();
@@ -18201,6 +18206,22 @@ bool OsmAndPoiBoxDataAtom::MergePartialFromCodedStream(
           goto handle_uninterpreted;
         }
         if (input->ExpectTag(122)) goto parse_textValues;
+        if (input->ExpectTag(128)) goto parse_precisionXY;
+        break;
+      }
+
+      // optional int32 precisionXY = 16;
+      case 16: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
+         parse_precisionXY:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &precisionxy_)));
+          set_has_precisionxy();
+        } else {
+          goto handle_uninterpreted;
+        }
         if (input->ExpectAtEnd()) return true;
         break;
       }
@@ -18319,6 +18340,11 @@ void OsmAndPoiBoxDataAtom::SerializeWithCachedSizes(
       15, this->textvalues(i), output);
   }
 
+  // optional int32 precisionXY = 16;
+  if (has_precisionxy()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(16, this->precisionxy(), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -18429,6 +18455,11 @@ void OsmAndPoiBoxDataAtom::SerializeWithCachedSizes(
       WriteStringToArray(15, this->textvalues(i), target);
   }
 
+  // optional int32 precisionXY = 16;
+  if (has_precisionxy()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(16, this->precisionxy(), target);
+  }
+
   if (!unknown_fields().empty()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -18503,6 +18534,13 @@ int OsmAndPoiBoxDataAtom::ByteSize() const {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::StringSize(
           this->note());
+    }
+
+    // optional int32 precisionXY = 16;
+    if (has_precisionxy()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->precisionxy());
     }
 
   }
@@ -18602,6 +18640,9 @@ void OsmAndPoiBoxDataAtom::MergeFrom(const OsmAndPoiBoxDataAtom& from) {
     if (from.has_note()) {
       set_note(from.note());
     }
+    if (from.has_precisionxy()) {
+      set_precisionxy(from.precisionxy());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -18639,6 +18680,7 @@ void OsmAndPoiBoxDataAtom::Swap(OsmAndPoiBoxDataAtom* other) {
     std::swap(note_, other->note_);
     textcategories_.Swap(&other->textcategories_);
     textvalues_.Swap(&other->textvalues_);
+    std::swap(precisionxy_, other->precisionxy_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/protos/OBF.pb.h
+++ b/protos/OBF.pb.h
@@ -5833,6 +5833,13 @@ class OsmAndPoiBoxDataAtom : public ::google::protobuf::Message {
   inline const ::google::protobuf::RepeatedPtrField< ::std::string>& textvalues() const;
   inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_textvalues();
 
+  // optional int32 precisionXY = 16;
+  inline bool has_precisionxy() const;
+  inline void clear_precisionxy();
+  static const int kPrecisionXYFieldNumber = 16;
+  inline ::google::protobuf::int32 precisionxy() const;
+  inline void set_precisionxy(::google::protobuf::int32 value);
+
   // @@protoc_insertion_point(class_scope:OsmAnd.OBF.OsmAndPoiBoxDataAtom)
  private:
   inline void set_has_dx();
@@ -5853,6 +5860,8 @@ class OsmAndPoiBoxDataAtom : public ::google::protobuf::Message {
   inline void clear_has_phone();
   inline void set_has_note();
   inline void clear_has_note();
+  inline void set_has_precisionxy();
+  inline void clear_has_precisionxy();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -5869,9 +5878,10 @@ class OsmAndPoiBoxDataAtom : public ::google::protobuf::Message {
   ::std::string* note_;
   ::google::protobuf::RepeatedField< ::google::protobuf::uint32 > textcategories_;
   ::google::protobuf::RepeatedPtrField< ::std::string> textvalues_;
+  ::google::protobuf::int32 precisionxy_;
 
   mutable int _cached_size_;
-  ::google::protobuf::uint32 _has_bits_[(13 + 31) / 32];
+  ::google::protobuf::uint32 _has_bits_[(14 + 31) / 32];
 
   friend void  protobuf_AddDesc_OBF_2eproto();
   friend void protobuf_AssignDesc_OBF_2eproto();
@@ -14494,6 +14504,28 @@ OsmAndPoiBoxDataAtom::textvalues() const {
 inline ::google::protobuf::RepeatedPtrField< ::std::string>*
 OsmAndPoiBoxDataAtom::mutable_textvalues() {
   return &textvalues_;
+}
+
+// optional int32 precisionXY = 16;
+inline bool OsmAndPoiBoxDataAtom::has_precisionxy() const {
+  return (_has_bits_[0] & 0x00002000u) != 0;
+}
+inline void OsmAndPoiBoxDataAtom::set_has_precisionxy() {
+  _has_bits_[0] |= 0x00002000u;
+}
+inline void OsmAndPoiBoxDataAtom::clear_has_precisionxy() {
+  _has_bits_[0] &= ~0x00002000u;
+}
+inline void OsmAndPoiBoxDataAtom::clear_precisionxy() {
+  precisionxy_ = 0;
+  clear_has_precisionxy();
+}
+inline ::google::protobuf::int32 OsmAndPoiBoxDataAtom::precisionxy() const {
+  return precisionxy_;
+}
+inline void OsmAndPoiBoxDataAtom::set_precisionxy(::google::protobuf::int32 value) {
+  set_has_precisionxy();
+  precisionxy_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/src/Data/ObfPoiSectionReader_P.cpp
+++ b/src/Data/ObfPoiSectionReader_P.cpp
@@ -22,6 +22,10 @@
 #include <Logging.h>
 
 const int BUCKET_SEARCH_BY_NAME = 5;
+const int BASE_POI_SHIFT = 7;
+const int PRECISED_POI_SHIFT = 5;
+const int BASE_POI_ZOOM = 31 - BASE_POI_SHIFT;
+const int PRECISED_POI_ZOOM = 31 - PRECISED_POI_SHIFT;
 
 OsmAnd::ObfPoiSectionReader_P::ObfPoiSectionReader_P()
 {
@@ -870,6 +874,7 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
     QHash<int, QVariant> stringOrDataValues;
     auto categoriesFilterChecked = false;
     const CollatorStringMatcher matcher(query, StringMatcherMode::CHECK_STARTS_FROM_SPACE);
+    uint32_t precision = 0;
 
     for (;;)
     {
@@ -943,6 +948,13 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
 
                 amenity->nativeName = qMove(nativeName);
                 amenity->localizedNames = qMove(localizedNames);
+                if (precision > 0) {
+                    int xBase = position31.x >> BASE_POI_SHIFT;
+                    int yBase = position31.y >> BASE_POI_SHIFT;
+                    std::pair<int, int> precisedXY = OsmAnd::Utilities::calculateFinalXYFromBaseAndPrecisionXY(BASE_POI_ZOOM, PRECISED_POI_ZOOM, precision, xBase, yBase, true);
+                    position31.x = precisedXY.first << PRECISED_POI_SHIFT;
+                    position31.y = precisedXY.second << PRECISED_POI_SHIFT;
+                }
                 amenity->position31 = position31;
                 amenity->categories = qMove(categories);
                 if (autogenerateId)
@@ -966,14 +978,14 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
             {
                 const auto d = ObfReaderUtilities::readSInt32(cis);
                 assert(d >= 0);
-                position31.x = ((boxTileId.x << (24 - boxZoom)) + d) << 7;
+                position31.x = ((boxTileId.x << (BASE_POI_ZOOM - boxZoom)) + d) << BASE_POI_SHIFT;
                 break;
             }
             case OBF::OsmAndPoiBoxDataAtom::kDyFieldNumber:
             {
                 const auto d = ObfReaderUtilities::readSInt32(cis);
                 assert(d >= 0);
-                position31.y = ((boxTileId.y << (24 - boxZoom)) + d) << 7;
+                position31.y = ((boxTileId.y << (BASE_POI_ZOOM - boxZoom)) + d) << BASE_POI_SHIFT;
 
                 if (bbox31 && !bbox31->contains(position31))
                 {
@@ -1104,6 +1116,11 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
                 ObfReaderUtilities::readQString(cis, valueString);
 
                 stringOrDataValues.insert(subtypes->descriptionSubtypeIndex, valueString);
+                break;
+            }
+            case OBF::OsmAndPoiBoxDataAtom::kPrecisionXYFieldNumber:
+            {
+                cis->ReadVarint32(&precision);
                 break;
             }
             default:

--- a/src/Data/ObfPoiSectionReader_P.cpp
+++ b/src/Data/ObfPoiSectionReader_P.cpp
@@ -23,9 +23,9 @@
 
 const int BUCKET_SEARCH_BY_NAME = 5;
 const int BASE_POI_SHIFT = 7;
-const int PRECISED_POI_SHIFT = 5;
+const int FINAL_POI_SHIFT = 5;
 const int BASE_POI_ZOOM = 31 - BASE_POI_SHIFT;
-const int PRECISED_POI_ZOOM = 31 - PRECISED_POI_SHIFT;
+const int FINAL_POI_ZOOM = 31 - FINAL_POI_SHIFT;
 
 OsmAnd::ObfPoiSectionReader_P::ObfPoiSectionReader_P()
 {
@@ -874,7 +874,7 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
     QHash<int, QVariant> stringOrDataValues;
     auto categoriesFilterChecked = false;
     const CollatorStringMatcher matcher(query, StringMatcherMode::CHECK_STARTS_FROM_SPACE);
-    uint32_t precision = 0;
+    uint32_t precisionXY = 0;
 
     for (;;)
     {
@@ -948,12 +948,13 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
 
                 amenity->nativeName = qMove(nativeName);
                 amenity->localizedNames = qMove(localizedNames);
-                if (precision > 0) {
+                if (precisionXY > 0)
+                {
                     int xBase = position31.x >> BASE_POI_SHIFT;
                     int yBase = position31.y >> BASE_POI_SHIFT;
-                    std::pair<int, int> precisedXY = OsmAnd::Utilities::calculateFinalXYFromBaseAndPrecisionXY(BASE_POI_ZOOM, PRECISED_POI_ZOOM, precision, xBase, yBase, true);
-                    position31.x = precisedXY.first << PRECISED_POI_SHIFT;
-                    position31.y = precisedXY.second << PRECISED_POI_SHIFT;
+                    std::pair<int, int> precisedXY = OsmAnd::Utilities::calculateFinalXYFromBaseAndPrecisionXY(BASE_POI_ZOOM, FINAL_POI_ZOOM, precisionXY, xBase, yBase, true);
+                    position31.x = precisedXY.first << FINAL_POI_SHIFT;
+                    position31.y = precisedXY.second << FINAL_POI_SHIFT;
                 }
                 amenity->position31 = position31;
                 amenity->categories = qMove(categories);
@@ -1120,7 +1121,7 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
             }
             case OBF::OsmAndPoiBoxDataAtom::kPrecisionXYFieldNumber:
             {
-                cis->ReadVarint32(&precision);
+                cis->ReadVarint32(&precisionXY);
                 break;
             }
             default:

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <limits>
 #include <cmath>
+#include <stdexcept>
 
 #include "QtExtensions.h"
 #include <QtNumeric>
@@ -709,12 +710,16 @@ OsmAnd::PointD OsmAnd::Utilities::getTileEllipsoidNumberAndOffsetY(int zoom, dou
 }
 
 std::pair<int, int> OsmAnd::Utilities::calculateFinalXYFromBaseAndPrecisionXY(int bazeZoom, int finalZoom, int precisionXY,
-                                                                              int xBase, int yBase, bool ignoreNotEnoughPrecision) {
+                                                                              int xBase, int yBase, bool ignoreNotEnoughPrecision)
+{
     int finalX = xBase;
     int finalY = yBase;
-    for (int zoom = bazeZoom; zoom < finalZoom; zoom++) {
-        if (!ignoreNotEnoughPrecision) {
-            assert(precisionXY > 1);
+    int precisionCalc = precisionXY;
+    for (int zoom = bazeZoom; zoom < finalZoom; zoom++)
+    {
+        if (precisionXY <= 1 && precisionCalc > 0 && !ignoreNotEnoughPrecision)
+        {
+            throw std::invalid_argument( "Not enough bits to retrieve zoom approximation" );
         }
         finalY = finalY * 2 + (precisionXY & 1);
         finalX = finalX * 2 + ((precisionXY & 2) >> 1);

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -707,3 +707,18 @@ OsmAnd::PointD OsmAnd::Utilities::getTileEllipsoidNumberAndOffsetY(int zoom, dou
     res.y = floor(((xTilesCountForThisZoom / 2 - M2 * xTilesCountForThisZoom / 2 / M_PI) - yTileNumber) * tileSize);
     return res;
 }
+
+std::pair<int, int> OsmAnd::Utilities::calculateFinalXYFromBaseAndPrecisionXY(int bazeZoom, int finalZoom, int precisionXY,
+                                                                              int xBase, int yBase, bool ignoreNotEnoughPrecision) {
+    int finalX = xBase;
+    int finalY = yBase;
+    for (int zoom = bazeZoom; zoom < finalZoom; zoom++) {
+        if (!ignoreNotEnoughPrecision) {
+            assert(precisionXY > 1);
+        }
+        finalY = finalY * 2 + (precisionXY & 1);
+        finalX = finalX * 2 + ((precisionXY & 2) >> 1);
+        precisionXY = precisionXY >> 2;
+    }
+    return std::make_pair(finalX, finalY);
+}


### PR DESCRIPTION
Using precisionXY field from OBF.proto OsmAndPoiBoxDataAtom for set more precised coordinates for POI
Before:
![Screenshot 2021-02-17 at 15 13 31](https://user-images.githubusercontent.com/1040293/108209229-bb52c780-7132-11eb-817a-e592e82033cd.png)

After:
![Screenshot 2021-02-17 at 15 11 35](https://user-images.githubusercontent.com/1040293/108209261-c3ab0280-7132-11eb-8f16-6424702db837.png)
