### PR TITLE
Migrate drawing text on paths from legacy #16004

### DIFF
--- a/include/OsmAndCore/Map/IMapRenderer.h
+++ b/include/OsmAndCore/Map/IMapRenderer.h
@@ -173,6 +173,7 @@ namespace OsmAnd
         const ObservableAs<IMapRenderer::StateChanged> stateChangeObservable;
 
         //NOTE: screen points origin from top-left
+        virtual bool getWorldPointFromScreenPoint(const PointI& screenPoint, PointF& outWorldPoint) const = 0;
         virtual bool getLocationFromScreenPoint(const PointI& screenPoint, PointI& location31) const = 0;
         virtual bool getLocationFromScreenPoint(const PointI& screenPoint, PointI64& location) const = 0;
         virtual bool getLocationFromElevatedPoint(const PointI& screenPoint, PointI& location31,

--- a/include/OsmAndCore/Utilities.h
+++ b/include/OsmAndCore/Utilities.h
@@ -130,6 +130,14 @@ namespace OsmAnd
             return { (static_cast<double>(p.x) / tileSize31), (static_cast<double>(p.y) / tileSize31) };
         }
 
+        inline static PointI convertFloatTo31(const PointF& point, const PointI& target31, const ZoomLevel zoom)
+        {
+            const auto tileSize31 = (1u << (ZoomLevel::MaxZoomLevel - zoom));
+            const auto offsetFromTarget31 = static_cast<PointD>(point) * static_cast<double>(tileSize31);
+            const PointI64 location = static_cast<PointI64>(target31) + static_cast<PointI64>(offsetFromTarget31);
+            return Utilities::normalizeCoordinates(location, ZoomLevel::ZoomLevel31);
+        }
+
         inline static double normalizeLatitude(double latitude)
         {
             while (latitude < -90.0 || latitude > 90.0)

--- a/src/Map/AtlasMapRendererSymbolsStage.h
+++ b/src/Map/AtlasMapRendererSymbolsStage.h
@@ -17,6 +17,7 @@
 #include "QuadTree.h"
 #include "AtlasMapRendererStage.h"
 #include "GPUAPI.h"
+#include "SkPath.h"
 
 namespace OsmAnd
 {
@@ -296,21 +297,7 @@ namespace OsmAnd
 
         static bool segmentValidFor2D(const glm::vec2& vSegment);
 
-        static glm::vec2 computePathDirection(
-            const QVector<glm::vec2>& path,
-            const unsigned int startPathPointIndex,
-            const glm::vec2& exactStartPoint,
-            const unsigned int endPathPointIndex,
-            const glm::vec2& exactEndPoint);
-
-        double computeDistanceBetweenCameraToPath(
-            const QVector<glm::vec2>& pathInWorld,
-            const unsigned int startPathPointIndex,
-            const glm::vec2& exactStartPointInWorld,
-            const unsigned int endPathPointIndex,
-            const glm::vec2& exactEndPointInWorld) const;
-
-        QVector<RenderableOnPathSymbol::GlyphPlacement> computePlacementOfGlyphsOnPath(
+        SkPath computePathForGlyphsPlacement(
             const bool is2D,
             const QVector<glm::vec2>& pathOnScreen,
             const QVector<float>& pathSegmentsLengthsOnScreen,
@@ -321,6 +308,27 @@ namespace OsmAnd
             const unsigned int endPathPointIndex,
             const glm::vec2& directionOnScreen,
             const QVector<float>& glyphsWidths) const;
+
+        glm::vec2 computePathDirection(const SkPath& path) const;
+
+        double computeDistanceFromCameraToPath(const SkPath& pathInWorld) const;
+
+        SkPath convertPathOnScreenToWorld(const SkPath& pathOnScreen, bool& outOk) const;
+
+        SkPath projectPathInWorldToScreen(const SkPath& pathInWorld) const;
+
+        QVector<RenderableOnPathSymbol::GlyphPlacement> computePlacementOfGlyphsOnPath(
+            const SkPath& path,
+            const bool is2D,
+            const glm::vec2& directionOnScreen,
+            const QVector<float>& glyphsWidths) const;
+
+        bool computeGlyphPlacementOnPath(
+            const glm::vec2& anchorPoint,
+            const bool is2D,
+            glm::vec2& outAnchorPoint,
+            float& outGlyphDepth,
+            bool& outHasElevationData) const;
 
         OOBBF calculateOnPath2dOOBB(const std::shared_ptr<RenderableOnPathSymbol>& renderable) const;
 

--- a/src/Map/OpenGL/AtlasMapRenderer_OpenGL.cpp
+++ b/src/Map/OpenGL/AtlasMapRenderer_OpenGL.cpp
@@ -1072,6 +1072,25 @@ float OsmAnd::AtlasMapRenderer_OpenGL::getTileSizeOnScreenInPixels() const
     return ok ? internalState.referenceTileSizeOnScreenInPixels * internalState.tileOnScreenScaleFactor : 0.0;
 }
 
+bool OsmAnd::AtlasMapRenderer_OpenGL::getWorldPointFromScreenPoint(const PointI& screenPoint, PointF& outWorldPoint) const
+{
+    const auto state = getState();
+
+    InternalState internalState;
+    bool ok = updateInternalState(internalState, state, *getConfiguration(), true);
+    if (!ok)
+        return false;
+    
+    PointD position;
+    ok = getPositionFromScreenPoint(internalState, state, screenPoint, position);
+    if (!ok)
+        return false;
+    position *= AtlasMapRenderer::TileSize3D;
+
+    outWorldPoint = PointF(static_cast<float>(position.x), static_cast<float>(position.y));
+    return true;
+}
+
 bool OsmAnd::AtlasMapRenderer_OpenGL::getLocationFromScreenPoint(const PointI& screenPoint, PointI& location31) const
 {
     PointI64 location;

--- a/src/Map/OpenGL/AtlasMapRenderer_OpenGL.h
+++ b/src/Map/OpenGL/AtlasMapRenderer_OpenGL.h
@@ -100,6 +100,7 @@ namespace OsmAnd
 
         float getTileSizeOnScreenInPixels() const override;
 
+        bool getWorldPointFromScreenPoint(const PointI& screenPoint, PointF& outWorldPoint) const override;
         bool getLocationFromScreenPoint(const PointI& screenPoint, PointI& location31) const override;
         bool getLocationFromScreenPoint(const PointI& screenPoint, PointI64& location) const override;
         bool getLocationFromElevatedPoint(const PointI& screenPoint, PointI& location31,


### PR DESCRIPTION
1) Text of 1..4 glyphs is drawn on straight
2) Text of 5+ glyphs is drawn on simplified path, where
   each 1st and 2nd glyph in group of 3 are drawn on one segment