### PR TITLE
Support PNG rasters in fonts

### DIFF
--- a/externals/freetype/CMakeLists.txt
+++ b/externals/freetype/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(freetype_static STATIC
 )
 add_dependencies(freetype_static
 	z_static
+	png_static
 )
 
 check_include_file("unistd.h" HAVE_UNISTD_H)
@@ -85,4 +86,5 @@ target_include_directories(freetype_static
 target_link_libraries(freetype_static
 	LINK_PUBLIC
 		z_static
+		png_static
 )

--- a/externals/freetype/ftoption-override.h
+++ b/externals/freetype/ftoption-override.h
@@ -269,7 +269,7 @@ FT_BEGIN_HEADER
    *   options set by those programs have precedence, overwriting the value
    *   here with the configured one.
    */
-/* #define FT_CONFIG_OPTION_USE_PNG */
+#define FT_CONFIG_OPTION_USE_PNG
 
 
   /**************************************************************************


### PR DESCRIPTION
Enable PNG in Freetype to support CBDT fonts