### PR TITLE
Remove question marks from symbol texts in iOS

### DIFF
--- a/src/SystemTypefaceFinder.cpp
+++ b/src/SystemTypefaceFinder.cpp
@@ -28,6 +28,11 @@ std::shared_ptr<const OsmAnd::ITypefaceFinder::Typeface> OsmAnd::SystemTypefaceF
         return nullptr;
     }
 
+    SkString typefaceName;
+    pTypeface->getFamilyName(&typefaceName);
+    if (typefaceName.contains("LastResort"))
+        return nullptr;
+
     const auto skTypeface = pTypeface->makeClone({});
     if (!skTypeface)
     {


### PR DESCRIPTION
Don't use iOS LastResort font to show question marks for invisible or unavailabe characters