### PR TITLE
Don't overscale basemap data, read from all zooms instead

### DIFF
--- a/src/ObfDataInterface.cpp
+++ b/src/ObfDataInterface.cpp
@@ -64,7 +64,7 @@ bool OsmAnd::ObfDataInterface::loadBinaryMapObjects(
     QList< std::shared_ptr<const OsmAnd::BinaryMapObject> >* resultOut,
     MapSurfaceType* outSurfaceType,
     const ZoomLevel zoom,
-    const AreaI* const bbox31 /*= nullptr*/,
+    const AreaI* const bbox31_ /*= nullptr*/,
     const ObfMapSectionReader::FilterByIdFunction filterById /*= nullptr*/,
     ObfMapSectionReader::DataBlocksCache* cache /*= nullptr*/,
     QList< std::shared_ptr<const ObfMapSectionReader::DataBlock> >* outReferencedCacheEntries /*= nullptr*/,
@@ -82,9 +82,14 @@ bool OsmAnd::ObfDataInterface::loadBinaryMapObjects(
 
         const auto& obfInfo = obfReader->obtainInfo();
 
+        const AreaI* bbox31 = bbox31_;
+        
         // Handle main basemap
         if (obfInfo->isBasemapWithCoastlines)
         {
+            if (coastlineOnly)
+                continue;
+            
             // In case there's more than 1 basemap reader present, use only first and warn about this fact
             if (basemapReader)
             {
@@ -95,9 +100,13 @@ bool OsmAnd::ObfDataInterface::loadBinaryMapObjects(
             // Save basemap reader for later use
             basemapReader = obfReader;
 
-            // In case requested zoom is more detailed than basemap max zoom, skip basemap processing for now
-            if (zoom > static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel))
-                continue;
+            // Enlarge bbox to find more coastlines from basemap
+            if (bbox31_ && zoom > ObfMapSectionLevel::MaxBasemapZoomLevel)
+            {
+                const auto roundZoom = static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel);
+                const auto& roundedBBox31 = Utilities::roundBoundingBox31(*bbox31_, roundZoom);
+                bbox31 = &roundedBBox31;
+            }
         }
 
         for (const auto& mapSection : constOf(obfInfo->mapSections))
@@ -128,54 +137,6 @@ bool OsmAnd::ObfDataInterface::loadBinaryMapObjects(
                 else if (mergedSurfaceType != surfaceTypeToMerge)
                     mergedSurfaceType = MapSurfaceType::Mixed;
             }
-        }
-    }
-
-    // In case there's basemap available and requested zoom is more detailed than basemap max zoom level,
-    // read tile from MaxBasemapZoomLevel that covers requested tile
-    if (basemapReader && zoom > static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel) && !coastlineOnly)
-    {
-        const auto& obfInfo = basemapReader->obtainInfo();
-
-        // Calculate proper bbox31 on MaxBasemapZoomLevel (if possible)
-        const AreaI *pBasemapBBox31 = nullptr;
-        AreaI basemapBBox31;
-        if (bbox31)
-        {
-            pBasemapBBox31 = &basemapBBox31;
-            basemapBBox31 = Utilities::roundBoundingBox31(
-                *bbox31,
-                static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel));
-        }
-
-        for (const auto& mapSection : constOf(obfInfo->mapSections))
-        {
-            if (queryController && queryController->isAborted())
-                return false;
-
-            // Read objects from each map section
-            auto surfaceTypeToMerge = MapSurfaceType::Undefined;
-            OsmAnd::ObfMapSectionReader::loadMapObjects(
-                basemapReader,
-                mapSection,
-                static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel),
-                pBasemapBBox31,
-                resultOut,
-                &surfaceTypeToMerge,
-                filterById,
-                nullptr,
-                cache,
-                outReferencedCacheEntries,
-                queryController,
-                metric,
-                false);
-
-            // Basemap must always have a surface type defined
-            assert(surfaceTypeToMerge != MapSurfaceType::Undefined);
-            if (mergedSurfaceType == MapSurfaceType::Undefined)
-                mergedSurfaceType = surfaceTypeToMerge;
-            else if (mergedSurfaceType != surfaceTypeToMerge)
-                mergedSurfaceType = MapSurfaceType::Mixed;
         }
     }
 
@@ -256,7 +217,7 @@ bool OsmAnd::ObfDataInterface::loadMapObjects(
     QList< std::shared_ptr<const OsmAnd::Road> >* outRoads,
     MapSurfaceType* outSurfaceType,
     const ZoomLevel zoom,
-    const AreaI* const bbox31 /*= nullptr*/,
+    const AreaI* const bbox31_ /*= nullptr*/,
     const ObfMapSectionReader::FilterByIdFunction filterMapObjectsById /*= nullptr*/,
     ObfMapSectionReader::DataBlocksCache* binaryMapObjectsCache /*= nullptr*/,
     QList< std::shared_ptr<const ObfMapSectionReader::DataBlock> >* outReferencedBinaryMapObjectsCacheEntries /*= nullptr*/,
@@ -306,6 +267,8 @@ bool OsmAnd::ObfDataInterface::loadMapObjects(
         QFileInfo fileInfo(obfReader->obfFile->filePath);
         if (obfReader->obfFile->filePath.contains(QStringLiteral(".road")) && regularMapNames.contains(fileInfo.baseName()))
             continue;
+        
+        const AreaI* bbox31 = bbox31_;
 
         // Handle basemap
         if (obfInfo->isBasemapWithCoastlines)
@@ -313,9 +276,14 @@ bool OsmAnd::ObfDataInterface::loadMapObjects(
             // Ignore this basemap if skipped before
             if (basemapReader && obfReader != basemapReader)
                 continue;
-            // In case requested zoom is more detailed than basemap max zoom, skip basemap processing for now
-            if (obfReader == basemapReader && zoom > static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel))
-                continue;
+            
+            // Enlarge bbox to find more coastlines from basemap
+            if (bbox31_ && zoom > ObfMapSectionLevel::MaxBasemapZoomLevel)
+            {
+                const auto roundZoom = static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel);
+                const auto& roundedBBox31 = Utilities::roundBoundingBox31(*bbox31_, roundZoom);
+                bbox31 = &roundedBBox31;
+            }
         }
 
         for (const auto& mapSection : constOf(obfInfo->mapSections))
@@ -345,53 +313,6 @@ bool OsmAnd::ObfDataInterface::loadMapObjects(
                 else if (mergedSurfaceType != surfaceTypeToMerge)
                     mergedSurfaceType = MapSurfaceType::Mixed;
             }
-        }
-    }
-
-    // In case there's basemap available and requested zoom is more detailed than basemap max zoom level,
-    // read tile from MaxBasemapZoomLevel that covers requested tile
-    if (basemapReader && zoom > static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel))
-    {
-        const auto& obfInfo = basemapReader->obtainInfo();
-
-        // Calculate proper bbox31 on MaxBasemapZoomLevel (if possible)
-        const AreaI *pBasemapBBox31 = nullptr;
-        AreaI basemapBBox31;
-        if (bbox31)
-        {
-            pBasemapBBox31 = &basemapBBox31;
-            basemapBBox31 = Utilities::roundBoundingBox31(
-                *bbox31,
-                static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel));
-        }
-
-        for (const auto& mapSection : constOf(obfInfo->mapSections))
-        {
-            if (queryController && queryController->isAborted())
-                return false;
-
-            // Read objects from each map section
-            auto surfaceTypeToMerge = MapSurfaceType::Undefined;
-            OsmAnd::ObfMapSectionReader::loadMapObjects(
-                basemapReader,
-                mapSection,
-                static_cast<ZoomLevel>(ObfMapSectionLevel::MaxBasemapZoomLevel),
-                pBasemapBBox31,
-                outBinaryMapObjects,
-                &surfaceTypeToMerge,
-                filterMapObjectsById,
-                nullptr,
-                binaryMapObjectsCache,
-                outReferencedBinaryMapObjectsCacheEntries,
-                queryController,
-                binaryMapObjectsMetric);
-
-            // Basemap must always have a surface type defined
-            assert(surfaceTypeToMerge != MapSurfaceType::Undefined);
-            if (mergedSurfaceType == MapSurfaceType::Undefined)
-                mergedSurfaceType = surfaceTypeToMerge;
-            else if (mergedSurfaceType != surfaceTypeToMerge)
-                mergedSurfaceType = MapSurfaceType::Mixed;
         }
     }
 
@@ -425,7 +346,7 @@ bool OsmAnd::ObfDataInterface::loadMapObjects(
                     obfReader,
                     routingSection,
                     RoutingDataLevel::Detailed,
-                    bbox31,
+                    bbox31_,
                     outRoads,
                     filterRoadsById,
                     nullptr,


### PR DESCRIPTION
Copy of PR https://github.com/osmandapp/OsmAnd-core/pull/576
To issue [Basemap display at close-up zoom levels](https://github.com/osmandapp/OsmAnd/issues/16559)