### PR TITLE
Hide invisible layers for low detail level tiles

### DIFF
--- a/include/OsmAndCore/Map/SqliteHeightmapTileProvider.h
+++ b/include/OsmAndCore/Map/SqliteHeightmapTileProvider.h
@@ -49,6 +49,7 @@ namespace OsmAnd
 
         virtual ZoomLevel getMinZoom() const Q_DECL_OVERRIDE;
         virtual ZoomLevel getMaxZoom() const Q_DECL_OVERRIDE;
+        virtual ZoomLevel getMaxVisibleZoom() const Q_DECL_OVERRIDE;
         virtual uint32_t getTileSize() const Q_DECL_OVERRIDE;
 
         virtual bool supportsNaturalObtainData() const Q_DECL_OVERRIDE;

--- a/src/Map/MapRendererResourcesManager.h
+++ b/src/Map/MapRendererResourcesManager.h
@@ -162,7 +162,8 @@ namespace OsmAnd
         void requestNeededTiledResources(
             const std::shared_ptr<MapRendererTiledResourcesCollection>& resourcesCollection,
             const QVector<TileId>& tiles,
-            const ZoomLevel zoom);
+            const ZoomLevel zoom,
+            const ZoomLevel currentZoom);
         void requestNeededKeyedResources(
             const std::shared_ptr<MapRendererKeyedResourcesCollection>& resourcesCollection,
             const ZoomLevel zoom);

--- a/src/Map/SqliteHeightmapTileProvider.cpp
+++ b/src/Map/SqliteHeightmapTileProvider.cpp
@@ -48,6 +48,13 @@ OsmAnd::ZoomLevel OsmAnd::SqliteHeightmapTileProvider::getMaxZoom() const
     return _p->getMaxZoom();
 }
 
+OsmAnd::ZoomLevel OsmAnd::SqliteHeightmapTileProvider::getMaxVisibleZoom() const
+{
+    const auto maxVisualZoom =
+        static_cast<ZoomLevel>(qMin(_p->getMaxZoom() + getMaxMissingDataZoomShift(), static_cast<int>(MaxZoomLevel)));
+    return maxVisualZoom;
+}
+
 uint32_t OsmAnd::SqliteHeightmapTileProvider::getTileSize() const
 {
     return outputTileSize;


### PR DESCRIPTION
Don't show invisible map layers at far tiles (lower detail levels)