### PR TITLE
Add places of discarded symbols to debug info

### DIFF
--- a/include/OsmAndCore/Map/AtlasMapRenderer_Metrics.h
+++ b/include/OsmAndCore/Map/AtlasMapRenderer_Metrics.h
@@ -72,6 +72,7 @@ namespace OsmAnd
                                                                                                                 \
         /* Time elapsed for debug stage */                                                                      \
         FIELD_ACTION(float, elapsedTimeForDebugStage, "s");                                                     \
+        FIELD_ACTION(float, elapsedTimeForDebugPoints2D, "s");                                                  \
         FIELD_ACTION(float, elapsedTimeForDebugRects2D, "s");                                                   \
         FIELD_ACTION(float, elapsedTimeForDebugLines2D, "s");                                                   \
         FIELD_ACTION(float, elapsedTimeForDebugLines3D, "s");                                                   \

--- a/include/OsmAndCore/Map/MapRendererDebugSettings.h
+++ b/include/OsmAndCore/Map/MapRendererDebugSettings.h
@@ -19,6 +19,7 @@ namespace OsmAnd
         bool excludeOnPathSymbolsFromProcessing;
         bool excludeBillboardSymbolsFromProcessing;
         bool excludeOnSurfaceSymbolsFromProcessing;
+        bool showSymbolsMarksRejectedByViewpoint;
         bool skipSymbolsIntersectionCheck;
         bool showSymbolsBBoxesAcceptedByIntersectionCheck;
         bool showSymbolsBBoxesRejectedByIntersectionCheck;

--- a/src/Map/AtlasMapRendererDebugStage.cpp
+++ b/src/Map/AtlasMapRendererDebugStage.cpp
@@ -11,10 +11,16 @@ OsmAnd::AtlasMapRendererDebugStage::~AtlasMapRendererDebugStage()
 
 void OsmAnd::AtlasMapRendererDebugStage::clear()
 {
+    _points2D.clear();
     _rects2D.clear();
     _lines2D.clear();
     _lines3D.clear();
     _quads3D.clear();
+}
+
+void OsmAnd::AtlasMapRendererDebugStage::addPoint2D(const PointF& point, const uint32_t argbColor)
+{
+    _points2D.push_back(qMove(Point2D(point, argbColor)));
 }
 
 void OsmAnd::AtlasMapRendererDebugStage::addRect2D(const AreaF& rect, const uint32_t argbColor, const float angle /*= 0.0f*/)

--- a/src/Map/AtlasMapRendererDebugStage.h
+++ b/src/Map/AtlasMapRendererDebugStage.h
@@ -21,6 +21,9 @@ namespace OsmAnd
     {
     private:
     protected:
+        typedef std::pair<PointF, uint32_t> Point2D;
+        QList<Point2D> _points2D;
+
         typedef std::tuple<AreaF, uint32_t, float> Rect2D;
         QList<Rect2D> _rects2D;
         
@@ -37,6 +40,7 @@ namespace OsmAnd
         virtual ~AtlasMapRendererDebugStage();
 
         virtual void clear();
+        virtual void addPoint2D(const PointF& point, const uint32_t argbColor);
         virtual void addRect2D(const AreaF& rect, const uint32_t argbColor, const float angle = 0.0f);
         virtual void addLine2D(const QVector<glm::vec2>& line, const uint32_t argbColor);
         virtual void addLine3D(const QVector<glm::vec3>& line, const uint32_t argbColor);

--- a/src/Map/AtlasMapRendererSymbolsStage.cpp
+++ b/src/Map/AtlasMapRendererSymbolsStage.cpp
@@ -1824,7 +1824,12 @@ void OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderablesFromOnPathSymbol(
 
     // If this symbol instance doesn't fit in both 2D and 3D, skip it
     if (!fits)
+    {
+        if (Q_UNLIKELY(debugSettings->showSymbolsMarksRejectedByViewpoint))
+            getRenderer()->debugStage->addPoint2D(
+                PointF(pinPointOnScreen.x, pinPointOnScreen.y), SkColorSetARGB(255, 128, 0, 0));
         return;
+    }
 
     // Compute exact points
     if (!is2D)
@@ -1862,7 +1867,12 @@ void OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderablesFromOnPathSymbol(
         symmetricOffset);
 
     if (path.size() < 2)
+    {
+        if (Q_UNLIKELY(debugSettings->showSymbolsMarksRejectedByViewpoint))
+            getRenderer()->debugStage->addPoint2D(
+                PointF(pinPointOnScreen.x, pinPointOnScreen.y), SkColorSetARGB(255, 255, 0, 0));
         return;
+    }
 
     ComputedPathData symbolPathData;
 
@@ -2045,7 +2055,16 @@ void OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderablesFromOnPathSymbol(
 
             outRenderableSymbols.push_back(renderable);
         }
+        else
+        {
+            if (Q_UNLIKELY(debugSettings->showSymbolsMarksRejectedByViewpoint))
+                getRenderer()->debugStage->addPoint2D(
+                    PointF(pinPointOnScreen.x, pinPointOnScreen.y), SkColorSetARGB(255, 255, 128, 64));
+            return;
+        }
     }
+    else
+        return;
 
     if (Q_UNLIKELY(debugSettings->showOnPathSymbolsRenderablesPaths))
     {
@@ -2391,10 +2410,10 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::applyMinDistanceToSameContentFromOthe
     if (hasSimilarContent)
     {
         if (Q_UNLIKELY(debugSettings->showSymbolsBBoxesRejectedByMinDistanceToSameContentFromOtherSymbolCheck))
-            addIntersectionDebugBox(renderable, ColorARGB::fromSkColor(SK_ColorRED).withAlpha(128));
+            addIntersectionDebugBox(renderable, ColorARGB(50, 160, 0, 255));
 
         if (Q_UNLIKELY(debugSettings->showSymbolsCheckBBoxesRejectedByMinDistanceToSameContentFromOtherSymbolCheck))
-            addIntersectionDebugBox(renderable->intersectionBBox.getEnlargedBy(symbol->minDistance), ColorARGB::fromSkColor(SK_ColorRED).withAlpha(128), false);
+            addIntersectionDebugBox(renderable->intersectionBBox.getEnlargedBy(symbol->minDistance), ColorARGB(50, 160, 0, 255), false);
 
         return false;
     }

--- a/src/Map/MapRendererDebugSettings.cpp
+++ b/src/Map/MapRendererDebugSettings.cpp
@@ -5,6 +5,7 @@ OsmAnd::MapRendererDebugSettings::MapRendererDebugSettings()
     , excludeOnPathSymbolsFromProcessing(false)
     , excludeBillboardSymbolsFromProcessing(false)
     , excludeOnSurfaceSymbolsFromProcessing(false)
+    , showSymbolsMarksRejectedByViewpoint(false)
     , skipSymbolsIntersectionCheck(false)
     , showSymbolsBBoxesAcceptedByIntersectionCheck(false)
     , showSymbolsBBoxesRejectedByIntersectionCheck(false)
@@ -42,6 +43,7 @@ void OsmAnd::MapRendererDebugSettings::copyTo(MapRendererDebugSettings& other) c
     other.excludeOnPathSymbolsFromProcessing = excludeOnPathSymbolsFromProcessing;
     other.excludeBillboardSymbolsFromProcessing = excludeBillboardSymbolsFromProcessing;
     other.excludeOnSurfaceSymbolsFromProcessing = excludeOnSurfaceSymbolsFromProcessing;
+    other.showSymbolsMarksRejectedByViewpoint = showSymbolsMarksRejectedByViewpoint;
     other.skipSymbolsIntersectionCheck = skipSymbolsIntersectionCheck;
     other.showSymbolsBBoxesRejectedByIntersectionCheck = showSymbolsBBoxesRejectedByIntersectionCheck;
     other.showSymbolsBBoxesAcceptedByIntersectionCheck = showSymbolsBBoxesAcceptedByIntersectionCheck;

--- a/src/Map/OpenGL/AtlasMapRendererDebugStage_OpenGL.h
+++ b/src/Map/OpenGL/AtlasMapRendererDebugStage_OpenGL.h
@@ -19,6 +19,37 @@ namespace OsmAnd
     {
     private:
     protected:
+        GLname _vaoPoint2D;
+        GLname _vboPoint2D;
+        GLname _iboPoint2D;
+        struct ProgramPoint2D {
+            GLname id;
+
+            struct {
+                // Input data
+                struct {
+                    GLlocation vertexPosition;
+                } in;
+
+                // Parameters
+                struct {
+                    // Common data
+                    GLlocation mProjectionViewModel;
+                    GLlocation point;
+                } param;
+            } vs;
+
+            struct {
+                // Parameters
+                struct {
+                    // Common data
+                    GLlocation color;
+                } param;
+            } fs;
+        } _programPoint2D;
+        bool initializePoints2D();
+        bool renderPoints2D();
+        bool releasePoints2D(bool gpuContextLost);
         GLname _vaoRect2D;
         GLname _vboRect2D;
         GLname _iboRect2D;


### PR DESCRIPTION
Use debug info to show special color marks for onpath symbols that were discarded by renderer