### PR TITLE
Hide symbols behind opaque volumetric vector lines

### DIFF
--- a/src/Map/AtlasMapRendererSymbolsStage.cpp
+++ b/src/Map/AtlasMapRendererSymbolsStage.cpp
@@ -201,6 +201,24 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
     AtlasMapRenderer_Metrics::Metric_renderFrame* const metric,
     bool forceUpdate /*= false*/)
 {
+    bool result = false;
+    
+    // Obtain and pre-render depths for volumetric symbols
+    QList<std::shared_ptr<const RenderableSymbol>> preRenderableSymbols;
+    ScreenQuadTree dummyIntersections;
+    result = obtainRenderableSymbols(
+            publishedMapSymbolsByOrder,
+            true,
+            preRenderableSymbols,
+            dummyIntersections,
+            nullptr,
+            metric);
+
+    if (!result)
+        return false;
+
+    preRender(preRenderableSymbols, metric);
+    
     Stopwatch stopwatch(metric != nullptr);
 
     // Overscaled/underscaled symbol resources were removed
@@ -213,8 +231,9 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
             return false;
 
         _lastAcceptedMapSymbolsByOrder.clear();
-        const auto result = obtainRenderableSymbols(
+        result = obtainRenderableSymbols(
             publishedMapSymbolsByOrder,
+            false,
             outRenderableSymbols,
             outIntersections,
             &_lastAcceptedMapSymbolsByOrder,
@@ -310,8 +329,9 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
     }
 
     // Otherwise, use last accepted map symbols by order
-    const auto result = obtainRenderableSymbols(
+    result = obtainRenderableSymbols(
         filteredLastAcceptedMapSymbols,
+        false,
         outRenderableSymbols,
         outIntersections,
         nullptr,
@@ -324,6 +344,7 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
 
 bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
     const MapRenderer::PublishedMapSymbolsByOrder& mapSymbolsByOrder,
+    const bool preRenderDenseSymbolsDepth,
     QList< std::shared_ptr<const RenderableSymbol> >& outRenderableSymbols,
     ScreenQuadTree& outIntersections,
     MapRenderer::PublishedMapSymbolsByOrder* pOutAcceptedMapSymbolsByOrder,
@@ -457,6 +478,12 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
                 const auto& mapSymbolsGroup = mapSymbolsEntry.first;
                 const auto& mapSymbolsFromGroup = mapSymbolsEntry.second;
 
+                const bool isDenseSymbolGroup = preRenderDenseSymbolsDepth
+                    && std::dynamic_pointer_cast<const VectorLine::SymbolsGroup>(mapSymbolsGroup);
+
+                if (preRenderDenseSymbolsDepth && !isDenseSymbolGroup)
+                    continue;
+
                 const bool freshlyPublishedGroup = std::dynamic_pointer_cast<const MapMarker::SymbolsGroup>(mapSymbolsGroup)
                     || std::dynamic_pointer_cast<const VectorLine::SymbolsGroup>(mapSymbolsGroup);
 
@@ -525,7 +552,7 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
                             computedPathsDataCache,
                             renderableSymbols,
                             outIntersections,
-                            applyFiltering,
+                            applyFiltering || preRenderDenseSymbolsDepth,
                             metric);
 
                         bool atLeastOnePlotted = false;
@@ -602,7 +629,7 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
                             computedPathsDataCache,
                             renderableSymbols,
                             outIntersections,
-                            applyFiltering,
+                            applyFiltering || preRenderDenseSymbolsDepth,
                             metric);
 
                         bool atLeastOnePlotted = false;

--- a/src/Map/AtlasMapRendererSymbolsStage.cpp
+++ b/src/Map/AtlasMapRendererSymbolsStage.cpp
@@ -203,21 +203,23 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
 {
     bool result = false;
     
-    // Obtain and pre-render depths for volumetric symbols
-    QList<std::shared_ptr<const RenderableSymbol>> preRenderableSymbols;
+    if (!publishedMapSymbolsByOrderLock.tryLockForRead())
+        return false;
+
+    // Obtain volumetric symbols to pre-render their depths
+    QList<std::shared_ptr<const RenderableSymbol>> volumetricSymbols;
     ScreenQuadTree dummyIntersections;
     result = obtainRenderableSymbols(
             publishedMapSymbolsByOrder,
             true,
-            preRenderableSymbols,
+            volumetricSymbols,
             dummyIntersections,
             nullptr,
             metric);
 
-    if (!result)
-        return false;
+    publishedMapSymbolsByOrderLock.unlock();
 
-    preRender(preRenderableSymbols, metric);
+    preRender(volumetricSymbols, metric);
     
     Stopwatch stopwatch(metric != nullptr);
 

--- a/src/Map/AtlasMapRendererSymbolsStage.h
+++ b/src/Map/AtlasMapRendererSymbolsStage.h
@@ -140,6 +140,7 @@ namespace OsmAnd
             bool forceUpdate = false);
         bool obtainRenderableSymbols(
             const MapRenderer::PublishedMapSymbolsByOrder& mapSymbolsByOrder,
+            const bool preRenderDenseSymbolsDepth,
             QList< std::shared_ptr<const RenderableSymbol> >& outRenderableSymbols,
             ScreenQuadTree& outIntersections,
             MapRenderer::PublishedMapSymbolsByOrder* pOutAcceptedMapSymbolsByOrder,
@@ -256,6 +257,8 @@ namespace OsmAnd
             AtlasMapRenderer_Metrics::Metric_renderFrame* metric = nullptr) const;
 
         // Terrain-related:
+        virtual bool preRender(QList< std::shared_ptr<const RenderableSymbol> >& preRenderableSymbols,
+            AtlasMapRenderer_Metrics::Metric_renderFrame* metric) = 0;
         virtual void clearTerrainVisibilityFiltering() = 0;
         virtual int startTerrainVisibilityFiltering(
             const PointF& pointOnScreen,

--- a/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.cpp
+++ b/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.cpp
@@ -97,8 +97,12 @@ bool OsmAnd::AtlasMapRendererSymbolsStage_OpenGL::render(IMapRenderer_Metrics::M
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
     GL_CHECK_RESULT;
     
+    _renderDepthOnly = true;
+
     prepare(metric);
     
+    _renderDepthOnly = false;
+
     // Resume drawing
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     GL_CHECK_RESULT;
@@ -2332,6 +2336,7 @@ bool OsmAnd::AtlasMapRendererSymbolsStage_OpenGL::initializeOnSurfaceVector()
         "        float extraCam = dist / length(param_vs_cameraPositionAndZfar.xyz);                                        ""\n"
         "        v.y += min(extraZfar, extraCam) + 0.1;                                                                     ""\n"
         "        gl_Position = param_vs_mPerspectiveProjectionView * v;                                                     ""\n"
+        "        gl_Position.z += param_vs_lookupOffsetAndScale.w;                                                          ""\n"
         "    }                                                                                                              ""\n"
         "    else if (abs(param_vs_elevation_scale.w) > 0.0 && param_vs_elevationInMeters == 0.0)                           ""\n"
         "    {                                                                                                              ""\n"
@@ -2349,6 +2354,7 @@ bool OsmAnd::AtlasMapRendererSymbolsStage_OpenGL::initializeOnSurfaceVector()
         "        float extraCam = dist / length(param_vs_cameraPositionAndZfar.xyz);                                        ""\n"
         "        v.y += min(extraZfar, extraCam) + 0.1;                                                                     ""\n"
         "        gl_Position = param_vs_mPerspectiveProjectionView * v;                                                     ""\n"
+        "        gl_Position.z += param_vs_lookupOffsetAndScale.w;                                                          ""\n"
         "    }                                                                                                              ""\n"
         "    else if (abs(param_vs_elevationInMeters) > 0.0)                                                                ""\n"
         "    {                                                                                                              ""\n"
@@ -2695,7 +2701,7 @@ bool OsmAnd::AtlasMapRendererSymbolsStage_OpenGL::renderOnSurfaceVectorSymbol(
             startPosition.x,
             startPosition.y,
             scaleFactor,
-            scaleFactor);
+            _renderDepthOnly ? internalState.zNear * 1.0001f : 0.0f);
         GL_CHECK_RESULT;
 
         // Set camera position and zFar distance to compute suitable elevation shift (against z-fighting)

--- a/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.h
+++ b/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.h
@@ -350,6 +350,8 @@ namespace OsmAnd
         ~AtlasMapRendererSymbolsStage_OpenGL() override;
 
         bool initialize() override;
+        bool preRender(QList< std::shared_ptr<const RenderableSymbol> >& preRenderableSymbols,
+            AtlasMapRenderer_Metrics::Metric_renderFrame* metric) override;
         bool render(IMapRenderer_Metrics::Metric_renderFrame* metric) override;
         bool release(bool gpuContextLost) override;
     };

--- a/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.h
+++ b/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.h
@@ -20,6 +20,7 @@ namespace OsmAnd
 
     private:
     protected:
+        bool _renderDepthOnly;
         GLname _lastUsedProgram;
         bool renderBillboardSymbol(
             const std::shared_ptr<const RenderableBillboardSymbol>& renderable,


### PR DESCRIPTION
Don't show symbols obscured by opaque volumetric vector lines