### PR TITLE
Fix direction when rendering bidirectional symbols

### DIFF
--- a/include/OsmAndCore/ICU.h
+++ b/include/OsmAndCore/ICU.h
@@ -16,8 +16,14 @@ namespace OsmAnd
 {
     namespace ICU
     {
+        enum TextDirection {
+            LTR,
+            RTL,
+            MIXED,
+            NEUTRAL
+        };
         OSMAND_CORE_API QString OSMAND_CORE_CALL convertToVisualOrder(const QString& input);
-        OSMAND_CORE_API bool OSMAND_CORE_CALL isRightToLeft(const QString& input);
+        OSMAND_CORE_API TextDirection OSMAND_CORE_CALL getTextDirection(const QString& input);
         OSMAND_CORE_API QString OSMAND_CORE_CALL transliterateToLatin(
             const QString& input,
             const bool keepAccentsAndDiacriticsInInput = true,

--- a/src/ICU.cpp
+++ b/src/ICU.cpp
@@ -185,9 +185,9 @@ OSMAND_CORE_API QString OSMAND_CORE_CALL OsmAnd::ICU::convertToVisualOrder(const
     return output;
 }
 
-OSMAND_CORE_API bool OSMAND_CORE_CALL OsmAnd::ICU::isRightToLeft(const QString& input)
+OSMAND_CORE_API OsmAnd::ICU::TextDirection OSMAND_CORE_CALL OsmAnd::ICU::getTextDirection(const QString& input)
 {
-    bool result = false;
+    auto result = MIXED;
     const auto len = input.length();
     UErrorCode icuError = U_ZERO_ERROR;
     bool ok = true;
@@ -197,7 +197,7 @@ OSMAND_CORE_API bool OSMAND_CORE_CALL OsmAnd::ICU::isRightToLeft(const QString& 
     if (pContext == nullptr || U_FAILURE(icuError))
     {
         LogPrintf(LogSeverityLevel::Error, "ICU error: %d", icuError);
-        return false;
+        return result;
     }
 
     // Configure context to reorder from logical to visual
@@ -207,8 +207,8 @@ OSMAND_CORE_API bool OSMAND_CORE_CALL OsmAnd::ICU::isRightToLeft(const QString& 
     ok = U_SUCCESS(icuError);
     if (ok)
     {
-        auto const direction = ubidi_getDirection(pContext);
-        result = direction != UBIDI_LTR;
+        auto const dir = ubidi_getDirection(pContext);
+        result = dir == UBIDI_LTR ? LTR : (dir == UBIDI_RTL ? RTL : (dir == UBIDI_MIXED ? MIXED : NEUTRAL));
     }
     else
         LogPrintf(LogSeverityLevel::Error, "ICU error: %d", icuError);

--- a/src/TextRasterizer_P.h
+++ b/src/TextRasterizer_P.h
@@ -103,8 +103,32 @@ namespace OsmAnd
             QVector<LinePaint>& paints,
             const SkScalar maxLineWidth,
             const Style::TextAlignment textAlignment) const;
-        bool drawPart(SkCanvas& canvas, const TextPaint& textPaint, QString text, bool rtl, SkPoint& origin) const;
+        bool drawPart(SkCanvas& canvas, const TextPaint& textPaint, const QString& text, bool rtl,
+            const std::shared_ptr<hb_buffer_t>& hbBuffer, SkPoint& origin) const;
         bool drawText(SkCanvas& canvas, const TextPaint& textPaint) const;
+        inline bool isRtlChar(const QChar& ch) const
+        {
+            auto d = ch.direction();
+            bool result = d == QChar::DirR
+                || d == QChar::DirAL
+                || d == QChar::DirRLE
+                || d == QChar::DirRLO
+                || d == QChar::DirRLI;
+            return result;
+        }
+        inline bool isNotRtlChar(const QChar& ch) const
+        {
+            return !isRtlChar(ch) && ch.direction() != QChar::DirAN;
+        }
+        inline bool isNotLtrChar(const QChar& ch) const
+        {
+            auto d = ch.direction();
+            bool result = d == QChar::DirB
+                || d == QChar::DirS
+                || d == QChar::DirWS
+                || d == QChar::DirON;
+            return result;
+        }
 
     protected:
         TextRasterizer_P(TextRasterizer* const owner);


### PR DESCRIPTION
Split and rasterize symbol text by parts with different directions