### PR TITLE
Fix crash during linking OpenGL shaders

### DIFF
--- a/src/Map/OpenGL/GPUAPI_OpenGL.cpp
+++ b/src/Map/OpenGL/GPUAPI_OpenGL.cpp
@@ -367,7 +367,6 @@ GLuint OsmAnd::GPUAPI_OpenGL::linkProgram(
             outVariablesMap->insert(name, { GlslVariableType::In, name, attributeType, attributeSize });
         }
     }
-    delete[] attributeName;
 
     GLint uniformsCount = 0;
     glGetProgramiv(program, GL_ACTIVE_UNIFORMS, &uniformsCount);
@@ -413,6 +412,7 @@ GLuint OsmAnd::GPUAPI_OpenGL::linkProgram(
             outVariablesMap->insert(name, { GlslVariableType::Uniform, name, uniformType, uniformSize });
         }
     }
+    delete[] attributeName;
     delete[] uniformName;
 
     return program;


### PR DESCRIPTION
Don't try to access freed memory while linking OpenGL shaders