### PR TITLE
Fix unnecessary underscale for POI symbols

### DIFF
--- a/include/OsmAndCore/Map/AmenitySymbolsProvider.h
+++ b/include/OsmAndCore/Map/AmenitySymbolsProvider.h
@@ -87,6 +87,8 @@ namespace OsmAnd
         virtual ZoomLevel getMinZoom() const Q_DECL_OVERRIDE;
         virtual ZoomLevel getMaxZoom() const Q_DECL_OVERRIDE;
 
+        virtual int getMaxMissingDataUnderZoomShift() const Q_DECL_OVERRIDE;
+
         virtual bool supportsNaturalObtainData() const Q_DECL_OVERRIDE;
         virtual bool obtainData(
             const IMapDataProvider::Request& request,

--- a/src/Map/AmenitySymbolsProvider.cpp
+++ b/src/Map/AmenitySymbolsProvider.cpp
@@ -37,6 +37,11 @@ OsmAnd::ZoomLevel OsmAnd::AmenitySymbolsProvider::getMaxZoom() const
     return MaxZoomLevel;
 }
 
+int OsmAnd::AmenitySymbolsProvider::getMaxMissingDataUnderZoomShift() const
+{
+    return 0;
+}
+
 bool OsmAnd::AmenitySymbolsProvider::supportsNaturalObtainData() const
 {
     return true;

--- a/src/Map/MapRendererResourcesManager.cpp
+++ b/src/Map/MapRendererResourcesManager.cpp
@@ -2016,7 +2016,7 @@ void OsmAnd::MapRendererResourcesManager::cleanupJunkResources(
             int maxMissingDataZoomShift = MapRenderer::MaxMissingDataZoomShift;
             int maxMissingDataUnderZoomShift = MapRenderer::MaxMissingDataUnderZoomShift;
 
-            if (tiledProvider && (resourcesType == MapRendererResourceType::MapLayer || resourcesType == MapRendererResourceType::ElevationData))
+            if (tiledProvider)
             {
                 minZoom = Utilities::clipZoomLevel(tiledProvider->getMinZoom());
                 maxZoom = Utilities::clipZoomLevel(tiledProvider->getMaxZoom());


### PR DESCRIPTION
Don't show POI symbols out of needed zoom range