### PR TITLE
Fix crash if GPU resource unloaded in wrong thread

### DIFF
--- a/src/Map/MapRendererKeyedSymbolsResource.cpp
+++ b/src/Map/MapRendererKeyedSymbolsResource.cpp
@@ -235,6 +235,7 @@ bool OsmAnd::MapRendererKeyedSymbolsResource::uploadToGPU()
 void OsmAnd::MapRendererKeyedSymbolsResource::unloadFromGPU()
 {
     _resourcesInGPU.clear();
+    _resourcesInGPUCache.clear();
 }
 
 void OsmAnd::MapRendererKeyedSymbolsResource::lostDataInGPU()


### PR DESCRIPTION
Unload unnecessary GPU resources in a proper thread