### PR TITLE
Use priority when processing resources of symbols

### DIFF
--- a/include/OsmAndCore/Map/IMapKeyedDataProvider.h
+++ b/include/OsmAndCore/Map/IMapKeyedDataProvider.h
@@ -57,7 +57,10 @@ namespace OsmAnd
 
         virtual ZoomLevel getMinZoom() const = 0;
         virtual ZoomLevel getMaxZoom() const = 0;
-        
+
+        virtual int64_t getPriority() const;
+        virtual void setPriority(int64_t priority);
+
         virtual QList<Key> getProvidedDataKeys() const = 0;
         virtual bool obtainKeyedData(
             const Request& request,

--- a/include/OsmAndCore/Map/VectorLinesCollection.h
+++ b/include/OsmAndCore/Map/VectorLinesCollection.h
@@ -31,6 +31,7 @@ namespace OsmAnd
         PrivateImplementation<VectorLinesCollection_P> _p;
         
         std::shared_ptr<VectorLineArrowsProvider> _arrowsProvider;
+        int64_t priority;
     protected:
     public:
         VectorLinesCollection();
@@ -58,6 +59,9 @@ namespace OsmAnd
         
         virtual ZoomLevel getMinZoom() const Q_DECL_OVERRIDE;
         virtual ZoomLevel getMaxZoom() const Q_DECL_OVERRIDE;
+
+        virtual int64_t getPriority() const Q_DECL_OVERRIDE;
+        virtual void setPriority(int64_t priority) Q_DECL_OVERRIDE;
 
     friend class OsmAnd::VectorLineBuilder;
     friend class OsmAnd::VectorLineBuilder_P;

--- a/src/Map/IMapKeyedDataProvider.cpp
+++ b/src/Map/IMapKeyedDataProvider.cpp
@@ -20,6 +20,15 @@ OsmAnd::ZoomLevel OsmAnd::IMapKeyedDataProvider::getMaxZoom() const
     return OsmAnd::MaxZoomLevel;
 }
 
+int64_t OsmAnd::IMapKeyedDataProvider::getPriority() const
+{
+    return std::numeric_limits<int64_t>::min();
+}
+
+void OsmAnd::IMapKeyedDataProvider::setPriority(int64_t priority)
+{
+}
+
 bool OsmAnd::IMapKeyedDataProvider::obtainKeyedData(
     const Request& request,
     std::shared_ptr<Data>& outKeyedData,

--- a/src/Map/MapRendererKeyedSymbolsResource.cpp
+++ b/src/Map/MapRendererKeyedSymbolsResource.cpp
@@ -15,8 +15,10 @@
 OsmAnd::MapRendererKeyedSymbolsResource::MapRendererKeyedSymbolsResource(
     MapRendererResourcesManager* owner_,
     const KeyedEntriesCollection<Key, MapRendererBaseKeyedResource>& collection_,
-    const Key key_)
+    const Key key_,
+    int64_t priority_ /* = std::numeric_limits<int64_t>::min() */)
     : MapRendererBaseKeyedResource(owner_, MapRendererResourceType::Symbols, collection_, key_)
+    , priority(priority_)
 {
 }
 
@@ -324,4 +326,9 @@ std::shared_ptr<const OsmAnd::GPUAPI::ResourceInGPU> OsmAnd::MapRendererKeyedSym
     if (citResourceInGPU == _resourcesInGPU.cend())
         return nullptr;
     return *citResourceInGPU;
+}
+
+int64_t OsmAnd::MapRendererKeyedSymbolsResource::getPriority() const
+{
+    return priority;
 }

--- a/src/Map/MapRendererKeyedSymbolsResource.h
+++ b/src/Map/MapRendererKeyedSymbolsResource.h
@@ -27,8 +27,10 @@ namespace OsmAnd
         MapRendererKeyedSymbolsResource(
             MapRendererResourcesManager* owner,
             const KeyedEntriesCollection<Key, MapRendererBaseKeyedResource>& collection,
-            const Key key);
+            const Key key,
+            int64_t priority = std::numeric_limits<int64_t>::min());
 
+        int64_t priority;
         std::shared_ptr<IMapKeyedSymbolsProvider::Data> _sourceData;
         std::shared_ptr<MapSymbolsGroup> _mapSymbolsGroup;
         QHash< std::shared_ptr<const MapSymbol>, std::shared_ptr<const GPUAPI::ResourceInGPU> > _resourcesInGPU;
@@ -56,6 +58,8 @@ namespace OsmAnd
         virtual void prepareResourcesRenew() Q_DECL_OVERRIDE;
         virtual void finishResourcesRenewing() Q_DECL_OVERRIDE;
         
+        int64_t getPriority() const;
+
     public:
         virtual ~MapRendererKeyedSymbolsResource();
 

--- a/src/Map/VectorLinesCollection.cpp
+++ b/src/Map/VectorLinesCollection.cpp
@@ -5,6 +5,7 @@
 
 OsmAnd::VectorLinesCollection::VectorLinesCollection()
     : _p(new VectorLinesCollection_P(this))
+    , priority(std::numeric_limits<int64_t>::min())
 {
 }
 
@@ -77,4 +78,14 @@ OsmAnd::ZoomLevel OsmAnd::VectorLinesCollection::getMinZoom() const
 OsmAnd::ZoomLevel OsmAnd::VectorLinesCollection::getMaxZoom() const
 {
     return OsmAnd::MaxZoomLevel;
+}
+
+int64_t OsmAnd::VectorLinesCollection::getPriority() const
+{
+    return priority;
+}
+
+void OsmAnd::VectorLinesCollection::setPriority(int64_t priority_)
+{
+    priority = priority_;
 }


### PR DESCRIPTION
Priority of provider is now used as a resource priority when processing resources of keyed symbols