### PR TITLE
Fix memory leak in vector lines collections

### DIFF
--- a/include/OsmAndCore/Map/VectorLinesCollection.h
+++ b/include/OsmAndCore/Map/VectorLinesCollection.h
@@ -30,7 +30,7 @@ namespace OsmAnd
     private:
         PrivateImplementation<VectorLinesCollection_P> _p;
         
-        std::shared_ptr<VectorLineArrowsProvider> _arrowsProvider;
+        std::weak_ptr<VectorLineArrowsProvider> _arrowsProvider;
         int64_t priority;
     protected:
     public:

--- a/src/Map/VectorLinesCollection.cpp
+++ b/src/Map/VectorLinesCollection.cpp
@@ -30,10 +30,14 @@ void OsmAnd::VectorLinesCollection::removeAllLines()
 
 const std::shared_ptr<OsmAnd::VectorLineArrowsProvider> OsmAnd::VectorLinesCollection::getVectorLineArrowsProvider()
 {
-    if (!_arrowsProvider)
-        _arrowsProvider = std::make_shared<VectorLineArrowsProvider>(shared_from_this());
+    auto arrowsProvider = _arrowsProvider.lock();
+    if (!arrowsProvider)
+    {
+        arrowsProvider = std::make_shared<VectorLineArrowsProvider>(shared_from_this());
+        _arrowsProvider = std::weak_ptr<VectorLineArrowsProvider>(arrowsProvider);
+    }
 
-    return _arrowsProvider;
+    return arrowsProvider;
 }
 
 QList<OsmAnd::IMapKeyedSymbolsProvider::Key> OsmAnd::VectorLinesCollection::getProvidedDataKeys() const


### PR DESCRIPTION
Remove strong cross references between lines collections and vector lines arrow providers