### PR TITLE
Fix zoom gestures when using exaggerated relief

### DIFF
--- a/src/Map/OpenGL/AtlasMapRenderer_OpenGL.cpp
+++ b/src/Map/OpenGL/AtlasMapRenderer_OpenGL.cpp
@@ -1910,7 +1910,7 @@ bool OsmAnd::AtlasMapRenderer_OpenGL::getExtraZoomAndRotationForAiming(const Map
     const PointD secondSegment(cameraLocation - secondCurrent);
     const PointD segmentLength(firstSegment.norm(), secondSegment.norm());
     PointD segmentRatio(firstHeightInMeters, secondHeightInMeters);
-    segmentRatio /= internalState.distanceFromCameraToGroundInMeters;
+    segmentRatio /= internalState.distanceFromCameraToGroundInMeters / state.elevationConfiguration.zScaleFactor;
     if (segmentRatio.x >= 1.0 || segmentRatio.y >= 1.0)
         segmentRatio = PointD();
     const PointD segmentOffset(segmentLength.x * segmentRatio.x, segmentLength.y * segmentRatio.y);


### PR DESCRIPTION
Use correct elevation values in zoom gesture calculations