### PR TITLE
Add exaggerated elevation for 3D-tracks

### DIFF
--- a/include/OsmAndCore/Map/GpxAdditionalIconsProvider.h
+++ b/include/OsmAndCore/Map/GpxAdditionalIconsProvider.h
@@ -92,7 +92,8 @@ namespace OsmAnd
             const SingleSkImage& startIcon,
             const SingleSkImage& finishIcon,
             const SingleSkImage& startFinishIcon,
-            const QList<float>& startFinishHeights = QList<float>());
+            const QList<float>& startFinishHeights = QList<float>(),
+            const float elevationScaleFactor = 1.0f);
         virtual ~GpxAdditionalIconsProvider();
         
         const int baseOrder;
@@ -105,6 +106,8 @@ namespace OsmAnd
         const sk_sp<const SkImage> startIcon;
         const sk_sp<const SkImage> finishIcon;
         const sk_sp<const SkImage> startFinishIcon;
+
+        const float elevationScaleFactor;
         
         virtual OsmAnd::ZoomLevel getMinZoom() const Q_DECL_OVERRIDE;
         virtual OsmAnd::ZoomLevel getMaxZoom() const Q_DECL_OVERRIDE;

--- a/src/Map/GpxAdditionalIconsProvider.cpp
+++ b/src/Map/GpxAdditionalIconsProvider.cpp
@@ -21,7 +21,8 @@ OsmAnd::GpxAdditionalIconsProvider::GpxAdditionalIconsProvider(
     const SingleSkImage& startIcon_,
     const SingleSkImage& finishIcon_,
     const SingleSkImage& startFinishIcon_,
-    const QList<float>& startFinishHeights_ /* = QList<float>() */)
+    const QList<float>& startFinishHeights_, /* = QList<float>() */
+    const float elevationScaleFactor_ /* = 1.0 */)
     : _cachedZoomLevel(MinZoomLevel)
     , _textRasterizer(TextRasterizer::getDefault())
     , baseOrder(baseOrder_)
@@ -32,6 +33,7 @@ OsmAnd::GpxAdditionalIconsProvider::GpxAdditionalIconsProvider(
     , finishIcon(finishIcon_.sp)
     , startFinishIcon(startFinishIcon_.sp)
     , startFinishHeights(startFinishHeights_)
+    , elevationScaleFactor(elevationScaleFactor_)
 {
     _captionStyle
         .setWrapWidth(100)
@@ -133,6 +135,7 @@ void OsmAnd::GpxAdditionalIconsProvider::buildSplitIntervalsSymbolsGroup(
             mapSymbol->languageId = OsmAnd::LanguageId::Invariant;
             mapSymbol->position31 = label.pos31;
             mapSymbol->elevation = label.height;
+            mapSymbol->elevationScaleFactor = elevationScaleFactor;
             mapSymbolsGroup->symbols.push_back(mapSymbol);
         }
     }
@@ -171,6 +174,7 @@ void OsmAnd::GpxAdditionalIconsProvider::buildStartFinishSymbolsGroup(
                 mapSymbol->languageId = LanguageId::Invariant;
                 mapSymbol->position31 = startPos31;
                 mapSymbol->elevation = startHeight;
+                mapSymbol->elevationScaleFactor = elevationScaleFactor;
                 mapSymbolsGroup->symbols.push_back(mapSymbol);
                 continue;
             }
@@ -184,6 +188,7 @@ void OsmAnd::GpxAdditionalIconsProvider::buildStartFinishSymbolsGroup(
             mapSymbol->languageId = OsmAnd::LanguageId::Invariant;
             mapSymbol->position31 = startPos31;
             mapSymbol->elevation = startHeight;
+            mapSymbol->elevationScaleFactor = elevationScaleFactor;
             mapSymbolsGroup->symbols.push_back(mapSymbol);
         }
         if (containsFinish && finishIcon)
@@ -195,6 +200,7 @@ void OsmAnd::GpxAdditionalIconsProvider::buildStartFinishSymbolsGroup(
             mapSymbol->languageId = OsmAnd::LanguageId::Invariant;
             mapSymbol->position31 = finishPos31;
             mapSymbol->elevation = finishHeight;
+            mapSymbol->elevationScaleFactor = elevationScaleFactor;
             mapSymbolsGroup->symbols.push_back(mapSymbol);
         }
     }


### PR DESCRIPTION
Use exaggerated elevation when rendering icons for 3D tracks