### PR TITLE
Make elevation provider when rendering 3D-symbols

### DIFF
--- a/include/OsmAndCore/Map/VectorLinesCollection.h
+++ b/include/OsmAndCore/Map/VectorLinesCollection.h
@@ -34,8 +34,10 @@ namespace OsmAnd
         int64_t priority;
     protected:
     public:
-        VectorLinesCollection();
+        VectorLinesCollection(const bool hasVolumetricSymbols = false);
         virtual ~VectorLinesCollection();
+
+        const bool hasVolumetricSymbols;
 
         QList<std::shared_ptr<OsmAnd::VectorLine>> getLines() const;
         bool removeLine(const std::shared_ptr<VectorLine>& line);

--- a/src/Map/VectorLinesCollection.cpp
+++ b/src/Map/VectorLinesCollection.cpp
@@ -3,8 +3,9 @@
 
 #include "MapDataProviderHelpers.h"
 
-OsmAnd::VectorLinesCollection::VectorLinesCollection()
+OsmAnd::VectorLinesCollection::VectorLinesCollection(const bool hasVolumetricSymbols_ /* = false */)
     : _p(new VectorLinesCollection_P(this))
+    , hasVolumetricSymbols(hasVolumetricSymbols_)
     , priority(std::numeric_limits<int64_t>::min())
 {
 }


### PR DESCRIPTION
Use elevation provider when heightmaps or volumetric symbols are present