### PR TITLE
Fix wrong NaN comparison in GLSL on old iOS device

### DIFF
--- a/include/OsmAndCore/Map/VectorMapSymbol.h
+++ b/include/OsmAndCore/Map/VectorMapSymbol.h
@@ -77,6 +77,8 @@ namespace OsmAnd
     public:
         virtual ~VectorMapSymbol();
         
+        static const float _absentElevation;
+
         const std::shared_ptr<VerticesAndIndices> getVerticesAndIndices() const;
         void setVerticesAndIndices(const std::shared_ptr<VerticesAndIndices>& verticesAndIndices);
 

--- a/include/Polyline2D/Polyline2D.h
+++ b/include/Polyline2D/Polyline2D.h
@@ -222,7 +222,7 @@ public:
         bool hasColorMapping = !colorizationMapping.isEmpty();
         bool hasOutlineColorMapping = !outlineColorizationMapping.isEmpty();
         bool hasHeights = heights.size() == points.size();
-        auto noHeight = std::numeric_limits<float>::quiet_NaN();
+        auto noHeight = OsmAnd::VectorMapSymbol::_absentElevation;
         auto outlineWidth = !hasHeights && outline > 0.0f ? outline : -1.0f;
         bool showOutline = outlineWidth >= 0.0f;
 		Vec2 startSide1, startSide2, endSide1, endSide2, nextStartSide1, nextStartSide2, lastSide1, lastSide2;
@@ -656,8 +656,10 @@ public:
             }
 
             if (showOutline) {
-                auto startBottom = std::isnan(startHeight) ? startHeight : startHeight - outline;
-                auto endBottom = std::isnan(endHeight) ? endHeight : endHeight - outline;
+                auto startBottom =
+                    startHeight == OsmAnd::VectorMapSymbol::_absentElevation ? startHeight : startHeight - outline;
+                auto endBottom =
+                    endHeight == OsmAnd::VectorMapSymbol::_absentElevation ? endHeight : endHeight - outline;
                 if (!Vec2Maths::equal(start1, end1)) {
                     if (!Vec2Maths::equal(startSide1, endSide1)) {
                         pVertex->color = startOuterColor;
@@ -1448,7 +1450,7 @@ private:
 
 			// connect the intersection points according to the joint style
             float top = height;
-            float bottom = std::isnan(height) ? height : height - outlineHeight;
+            float bottom = height == OsmAnd::VectorMapSymbol::_absentElevation ? height : height - outlineHeight;
 			if (jointStyle == JointStyle::BEVEL) {
                 // simply connect the intersection points
 				const Vec2& firstPoint = clockwise ? outer1->b : outer2->a;
@@ -1652,7 +1654,7 @@ private:
 		Vec2 startPoint = start;
 		Vec2 endPoint, startPointSide, endPointSide;
         float top = height;
-        float bottom = std::isnan(height) ? height : height - outlineHeight;
+        float bottom = height == OsmAnd::VectorMapSymbol::_absentElevation ? height : height - outlineHeight;
         bool showOutline = outlineWidth >= 0.0f;
         if (showOutline) {
             startPointSide = Vec2Maths::add(start, Vec2Maths::multiply(Vec2Maths::normalized(point1), outlineWidth));

--- a/src/Map/GeometryModifiers.cpp
+++ b/src/Map/GeometryModifiers.cpp
@@ -709,7 +709,7 @@ bool OsmAnd::GeometryModifiers::getTesselatedPlane(std::vector<VectorMapSymbol::
 	float w, u, rod, rate, xMin, xMax, yMin, yMax, wMin, wMax, uMin, uMax;
 	int32_t prev, next, c, iMinX, iMaxX, iMinY, iMaxY, iMinW, iMaxW, iMinU, iMaxU;
 	bool withTraceColorMap = !traceColorizationMapping.isEmpty();
-	float noHeight = std::numeric_limits<float>::quiet_NaN();
+	float noHeight = VectorMapSymbol::_absentElevation;
 	while (inObj.size() > 0)
 	{
 		xMin = std::numeric_limits<float>::max();

--- a/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.cpp
+++ b/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.cpp
@@ -2483,7 +2483,8 @@ bool OsmAnd::AtlasMapRendererSymbolsStage_OpenGL::renderOnSurfaceVectorSymbol(
         GL_CHECK_RESULT;
 
         // Set common elevation
-        glUniform1f(_onSurfaceVectorProgram.vs.param.elevationInMeters, renderable->elevationInMeters);
+        glUniform1f(_onSurfaceVectorProgram.vs.param.elevationInMeters, qIsNaN(renderable->elevationInMeters)
+            ? VectorMapSymbol::_absentElevation : renderable->elevationInMeters);
         GL_CHECK_RESULT;
 
         // Activate vertex buffer
@@ -2574,7 +2575,7 @@ bool OsmAnd::AtlasMapRendererSymbolsStage_OpenGL::renderOnSurfaceVectorSymbol(
         }
 
         // Reset common elevation
-        glUniform1f(_onSurfaceVectorProgram.vs.param.elevationInMeters, NAN);
+        glUniform1f(_onSurfaceVectorProgram.vs.param.elevationInMeters, VectorMapSymbol::_absentElevation);
         GL_CHECK_RESULT;
 
         // Set symbol position and scale for heightmap lookup

--- a/src/Map/Polygon_P.cpp
+++ b/src/Map/Polygon_P.cpp
@@ -316,7 +316,7 @@ std::shared_ptr<OsmAnd::OnSurfaceVectorMapSymbol> OsmAnd::Polygon_P::generatePri
     // generate triangles
     for (auto pointIdx = 0u; pointIdx + 2 < indices.size(); pointIdx += 3)
     {
-        pVertex->positionXYZ[1] = std::numeric_limits<float>::quiet_NaN();;
+        pVertex->positionXYZ[1] = VectorMapSymbol::_absentElevation;
         pVertex->positionXYZ[0] = original[indices[pointIdx]][0];
         pVertex->positionXYZ[2] = original[indices[pointIdx]][1];
         pVertex->color = owner->fillColor;

--- a/src/Map/VectorLine_P.cpp
+++ b/src/Map/VectorLine_P.cpp
@@ -1312,7 +1312,7 @@ std::shared_ptr<OsmAnd::OnSurfaceVectorMapSymbol> OsmAnd::VectorLine_P::generate
     if (vertices.size() == 0)
     {
         vertex.positionXYZ[0] = 0;
-        vertex.positionXYZ[1] = std::numeric_limits<float>::quiet_NaN();;
+        vertex.positionXYZ[1] = VectorMapSymbol::_absentElevation;
         vertex.positionXYZ[2] = 0;
         vertices.push_back(vertex);
         verticesAndIndices->position31 = new PointI(0, 0);

--- a/src/Map/VectorMapSymbol.cpp
+++ b/src/Map/VectorMapSymbol.cpp
@@ -1,5 +1,7 @@
 #include "VectorMapSymbol.h"
 
+const float OsmAnd::VectorMapSymbol::_absentElevation = -13e9f;
+
 OsmAnd::VectorMapSymbol::VectorMapSymbol(
     const std::shared_ptr<MapSymbolsGroup>& group_)
     : MapSymbol(group_)
@@ -103,7 +105,7 @@ void OsmAnd::VectorMapSymbol::generateCirclePrimitive(
 
     // First vertex is the center
     pVertex->positionXYZ[0] = 0.0f;
-    pVertex->positionXYZ[1] = std::numeric_limits<float>::quiet_NaN();
+    pVertex->positionXYZ[1] = _absentElevation;
     pVertex->positionXYZ[2] = 0.0f;
     pVertex->color = color;
     pVertex += 1;
@@ -114,7 +116,7 @@ void OsmAnd::VectorMapSymbol::generateCirclePrimitive(
     {
         const auto angle = step * pointIdx;
         pVertex->positionXYZ[0] = radius * qCos(angle);
-        pVertex->positionXYZ[1] = std::numeric_limits<float>::quiet_NaN();
+        pVertex->positionXYZ[1] = _absentElevation;
         pVertex->positionXYZ[2] = radius * qSin(angle);
         pVertex->color = color;
 
@@ -123,7 +125,7 @@ void OsmAnd::VectorMapSymbol::generateCirclePrimitive(
 
     // Close the fan
     pVertex->positionXYZ[0] = verticesAndIndices->vertices[1].positionXYZ[0];
-    pVertex->positionXYZ[1] = std::numeric_limits<float>::quiet_NaN();
+    pVertex->positionXYZ[1] = _absentElevation;
     pVertex->positionXYZ[2] = verticesAndIndices->vertices[1].positionXYZ[2];
     pVertex->color = color;
     
@@ -161,7 +163,7 @@ void OsmAnd::VectorMapSymbol::generateRingLinePrimitive(
     {
         const auto angle = step * pointIdx;
         pVertex->positionXYZ[0] = radius * qCos(angle);
-        pVertex->positionXYZ[1] = std::numeric_limits<float>::quiet_NaN();
+        pVertex->positionXYZ[1] = _absentElevation;
         pVertex->positionXYZ[2] = radius * qSin(angle);
         pVertex->color = color;
 


### PR DESCRIPTION
Don't use NaN in GLSL shader due to incorrect NaN comparison on certain iOS devices