### PR TITLE
Hide similar symbols that are near to each other

### DIFF
--- a/include/OsmAndCore/Map/MapPrimitiviser.h
+++ b/include/OsmAndCore/Map/MapPrimitiviser.h
@@ -211,6 +211,7 @@ namespace OsmAnd
         public:
             virtual ~TextSymbol();
 
+            QString baseValue;
             QString value;
             LanguageId languageId;
             bool drawOnPath;

--- a/src/Map/MapPrimitiviser_P.cpp
+++ b/src/Map/MapPrimitiviser_P.cpp
@@ -2038,6 +2038,7 @@ void OsmAnd::MapPrimitiviser_P::obtainPrimitiveTexts(
         const std::shared_ptr<TextSymbol> text(new TextSymbol(primitive));
         text->location31 = location;
         text->languageId = languageId;
+        text->baseValue = caption;
         text->value = caption;
         text->scaleFactor = env->symbolsScaleFactor;
 

--- a/src/Map/SymbolRasterizer_P.cpp
+++ b/src/Map/SymbolRasterizer_P.cpp
@@ -180,7 +180,7 @@ void OsmAnd::SymbolRasterizer_P::rasterize(
                     rasterizedSymbol->image = qMove(rasterizedText);
                     rasterizedSymbol->order = textSymbol->order;
                     rasterizedSymbol->contentType = RasterizedSymbol::ContentType::Text;
-                    rasterizedSymbol->content = textSymbol->value;
+                    rasterizedSymbol->content = textSymbol->baseValue;
                     rasterizedSymbol->languageId = textSymbol->languageId;
                     rasterizedSymbol->minDistance = textSymbol->minDistance;
                     rasterizedSymbol->glyphsWidth = glyphsWidth;
@@ -253,7 +253,7 @@ void OsmAnd::SymbolRasterizer_P::rasterize(
                     rasterizedSymbol->image = rasterizedText;
                     rasterizedSymbol->order = textSymbol->order;
                     rasterizedSymbol->contentType = RasterizedSymbol::ContentType::Text;
-                    rasterizedSymbol->content = textSymbol->value;
+                    rasterizedSymbol->content = textSymbol->baseValue;
                     rasterizedSymbol->languageId = textSymbol->languageId;
                     rasterizedSymbol->minDistance = textSymbol->minDistance;
                     rasterizedSymbol->location31 = textSymbol->location31;


### PR DESCRIPTION
Don't show similar symbols that are close to each other