### PR TITLE
Use correct depth for raster symbols on surface

### DIFF
--- a/src/Map/AtlasMapRendererSymbolsStage.cpp
+++ b/src/Map/AtlasMapRendererSymbolsStage.cpp
@@ -467,7 +467,8 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
                 const auto& mapSymbolsFromGroup = mapSymbolsEntry.second;
 
                 const bool skipNotDenseSymbolGroup = preRenderDenseSymbolsDepth
-                    && !std::dynamic_pointer_cast<const VectorLine::SymbolsGroup>(mapSymbolsGroup);
+                    && !std::dynamic_pointer_cast<const VectorLine::SymbolsGroup>(mapSymbolsGroup)
+                    && !std::dynamic_pointer_cast<const MapMarker::SymbolsGroup>(mapSymbolsGroup);
 
                 if (skipNotDenseSymbolGroup)
                     continue;
@@ -475,7 +476,7 @@ bool OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderableSymbols(
                 const auto freshlyPublishedGroup =
                     std::dynamic_pointer_cast<const VectorLine::SymbolsGroup>(mapSymbolsGroup);
 
-                const bool canSkip = !applyFiltering && !freshlyPublishedGroup;
+                const bool canSkip = !applyFiltering && !freshlyPublishedGroup && !preRenderDenseSymbolsDepth;
 
                 const auto groupWithoutFiltering =
                     std::dynamic_pointer_cast<const MapMarker::SymbolsGroup>(mapSymbolsGroup);
@@ -1594,7 +1595,12 @@ void OsmAnd::AtlasMapRendererSymbolsStage::obtainRenderablesFromOnSurfaceSymbol(
     float elevationInWorld = surfaceInWorld;
     float elevationInMeters = NAN;
     if (const auto& rasterMapSymbol = std::dynamic_pointer_cast<const OnSurfaceRasterMapSymbol>(mapSymbol))
+    {
         elevationInMeters = rasterMapSymbol->getElevation();
+        // Raise elevated raster symbols to show them on top of dense objects
+        if (!qIsNaN(elevationInMeters))
+            elevationInWorld += 1.0f;
+    }
     if (!qIsNaN(elevationInMeters))
         elevationInWorld += elevationFactor * (elevationInMeters - surfaceInMeters) / metersPerUnit;
 

--- a/src/Map/OpenGL/AtlasMapRendererSymbolsStageModel3D_OpenGL.cpp
+++ b/src/Map/OpenGL/AtlasMapRendererSymbolsStageModel3D_OpenGL.cpp
@@ -198,6 +198,11 @@ bool OsmAnd::AtlasMapRendererSymbolsStageModel3D_OpenGL::render(
         .arg(QString::asprintf("%p", symbol->groupPtr))
         .arg(symbol->group.lock()->toString()));
 
+
+    // Enable depth buffer offset for all vector symbols (against z-fighting)
+    glEnable(GL_POLYGON_OFFSET_FILL);
+    GL_CHECK_RESULT;
+
     if (currentAlphaChannelType != AlphaChannelType::Straight)
     {
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -300,6 +305,10 @@ bool OsmAnd::AtlasMapRendererSymbolsStageModel3D_OpenGL::render(
         glDrawArrays(primitivesType, 0, count);
         GL_CHECK_RESULT;
     }
+
+    // Disable depth buffer offset for other symbols
+    glDisable(GL_POLYGON_OFFSET_FILL);
+    GL_CHECK_RESULT;
 
     GL_POP_GROUP_MARKER;
 

--- a/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.h
+++ b/src/Map/OpenGL/AtlasMapRendererSymbolsStage_OpenGL.h
@@ -191,7 +191,7 @@ namespace OsmAnd
         GLname _onSurfaceRasterSymbolVAO;
         GLname _onSurfaceRasterSymbolVBO;
         GLname _onSurfaceRasterSymbolIBO;
-        struct OnSurfaceSymbolProgram {
+        struct OnSurfaceRasterProgram {
             GLname id;
 
             struct {
@@ -210,7 +210,6 @@ namespace OsmAnd
                     GLlocation symbolOffsetFromTarget;
                     GLlocation direction;
                     GLlocation symbolSize;
-                    GLlocation zDistanceFromCamera;
                     GLlocation elevationInWorld;
                 } param;
             } vs;

--- a/src/Map/VectorMapSymbol.cpp
+++ b/src/Map/VectorMapSymbol.cpp
@@ -217,6 +217,7 @@ void OsmAnd::VectorMapSymbol::generateModel3DPrimitive(
 
         pVertex++;
     }
+    verticesAndIndices->isDenseObject = true;
 
     mapSymbol.setVerticesAndIndices(verticesAndIndices);
 }


### PR DESCRIPTION
Use correct depth values for raster symbols on elevated surface