### PR TITLE
Fix text direction of arabic symbols with numbers

### DIFF
--- a/src/TextRasterizer_P.cpp
+++ b/src/TextRasterizer_P.cpp
@@ -287,7 +287,7 @@ bool OsmAnd::TextRasterizer_P::getGlyphBlocks(QVector<LinePaint>& paints, int& o
                         k++;
                         j = k;
                     }
-                    else if (isNotLtrChar(text[k]))
+                    else if (isNotLtrChar(text[k]) || text[k].direction() == QChar::DirEN)
                         k++;
                     else
                         break;


### PR DESCRIPTION
Use correct text direction for arabic symbols  with numbers inside.