### PR TITLE
Fix MTE in map animations

### DIFF
--- a/src/Map/MapMarkersAnimator_P.cpp
+++ b/src/Map/MapMarkersAnimator_P.cpp
@@ -264,7 +264,7 @@ bool OsmAnd::MapMarkersAnimator_P::update(const float timePassed)
     while(itAnimations.hasNext())
     {
         auto item = itAnimations.next();
-        auto& key = item.key();
+        auto key = item.key();
         auto& animations = item.value();
 
         {


### PR DESCRIPTION
Don't use reference to deleted object