### PR TITLE
Fix raster symbols seen through terrain

### DIFF
--- a/src/Map/AtlasMapRendererStage.h
+++ b/src/Map/AtlasMapRendererStage.h
@@ -27,10 +27,17 @@ namespace OsmAnd
     private:
     protected:
         std::shared_ptr<const GPUAPI::ResourceInGPU> captureElevationDataResource(
-            TileId normalizedTileId, ZoomLevel zoomLevel, std::shared_ptr<const IMapElevationDataProvider::Data>* pOutSource = nullptr) const;
+            TileId normalizedTileId,
+            ZoomLevel zoomLevel,
+            std::shared_ptr<const IMapElevationDataProvider::Data>* pOutSource = nullptr,
+            bool* isNotReady = nullptr) const;
 
-        OsmAnd::ZoomLevel getElevationData(TileId normalizedTileId, ZoomLevel zoomLevel, PointF& offsetInTileN,
-            std::shared_ptr<const IMapElevationDataProvider::Data>* pOutSource = nullptr) const;
+        OsmAnd::ZoomLevel getElevationData(
+            TileId normalizedTileId,
+            ZoomLevel zoomLevel,
+            PointF& offsetInTileN,
+            std::shared_ptr<const IMapElevationDataProvider::Data>* pOutSource = nullptr,
+            bool* isNotReady = nullptr) const;
 
     public:
         explicit AtlasMapRendererStage(AtlasMapRenderer* renderer);


### PR DESCRIPTION
Don't display on-surface raster symbols when heightmap data isn't yet ready.