### PR TITLE
Enable cancelling of internally processed resource

### DIFF
--- a/src/Map/MapRendererResourcesManager.cpp
+++ b/src/Map/MapRendererResourcesManager.cpp
@@ -2702,7 +2702,7 @@ bool OsmAnd::MapRendererResourcesManager::cleanupJunkResource(
         // If resource request is being processed, keep the entry until processing is complete.
 
         // Cancel the task
-        if (resource->type == MapRendererResourceType::MapLayer && resource->supportsObtainDataAsync())
+        if (resource->type == MapRendererResourceType::MapLayer)
         {
             assert(resource->_cancelRequestCallback != nullptr);
             resource->_cancelRequestCallback();


### PR DESCRIPTION
Unblock cancelling for internally processed (sync) resources.