### PR TITLE
Don't hide extra labels of polygons

### DIFF
--- a/include/OsmAndCore/Map/MapPrimitiviser.h
+++ b/include/OsmAndCore/Map/MapPrimitiviser.h
@@ -132,11 +132,12 @@ namespace OsmAnd
         private:
         protected:
             SymbolsGroup(
-                const std::shared_ptr<const MapObject>& sourceObject);
+                const std::shared_ptr<const MapObject>& sourceObject, bool canBeShownWithoutIcon = false);
         public:
             ~SymbolsGroup();
 
             const std::shared_ptr<const MapObject> sourceObject;
+            bool canBeShownWithoutIcon;
 
             SymbolsCollection symbols;
         

--- a/include/OsmAndCore/Map/SymbolRasterizer.h
+++ b/include/OsmAndCore/Map/SymbolRasterizer.h
@@ -40,10 +40,12 @@ namespace OsmAnd
         private:
         protected:
         public:
-            RasterizedSymbolsGroup(const std::shared_ptr<const MapObject>& mapObject);
+            RasterizedSymbolsGroup(const std::shared_ptr<const MapObject>& mapObject,
+                bool canBeShownWithoutIcon = false);
             virtual ~RasterizedSymbolsGroup();
 
             const std::shared_ptr<const MapObject> mapObject;
+            const bool canBeShownWithoutIcon;
             QList< std::shared_ptr<const RasterizedSymbol> > symbols;
         };
 

--- a/src/Map/MapObjectsSymbolsProvider_P.cpp
+++ b/src/Map/MapObjectsSymbolsProvider_P.cpp
@@ -508,8 +508,11 @@ bool OsmAnd::MapObjectsSymbolsProvider_P::obtainData(
         {
             if (hasAtLeastOneSimpleBillboard && !(hasAtLeastOneOnPath || hasAtLeastOneAlongPathBillboard))
             {
-                group->presentationMode |= MapSymbolsGroup::PresentationModeFlag::ShowNoneIfIconIsNotShown;
-                group->presentationMode |= MapSymbolsGroup::PresentationModeFlag::ShowAnythingUntilFirstGap;
+                if (!rasterizedGroup->canBeShownWithoutIcon)
+                {
+                    group->presentationMode |= MapSymbolsGroup::PresentationModeFlag::ShowNoneIfIconIsNotShown;
+                    group->presentationMode |= MapSymbolsGroup::PresentationModeFlag::ShowAnythingUntilFirstGap;
+                }
             }
             else
             {

--- a/src/Map/MapPrimitiviser.cpp
+++ b/src/Map/MapPrimitiviser.cpp
@@ -134,8 +134,9 @@ OsmAnd::MapPrimitiviser::Primitive::~Primitive()
 }
 
 OsmAnd::MapPrimitiviser::SymbolsGroup::SymbolsGroup(
-    const std::shared_ptr<const MapObject>& sourceObject_)
+    const std::shared_ptr<const MapObject>& sourceObject_, bool canBeShownWithoutIcon_ /* = false */)
     : sourceObject(sourceObject_)
+    , canBeShownWithoutIcon(canBeShownWithoutIcon_)
 {
 }
 

--- a/src/Map/MapPrimitiviser_P.cpp
+++ b/src/Map/MapPrimitiviser_P.cpp
@@ -1381,8 +1381,8 @@ void OsmAnd::MapPrimitiviser_P::obtainPrimitivesSymbols(
         // (using shared cache is only allowed for non-generated MapObjects),
         // then symbols group can be shared (excluding labeled polygons)
         MapObject::SharingKey sharingKey;
-        const auto canBeShared = primitivesGroup->sourceObject->obtainSharingKey(sharingKey)
-            && (primitivesGroup->polygons.isEmpty() || primitivesGroup->points.isEmpty());
+        const bool isLabeledPolygon = !primitivesGroup->polygons.isEmpty() && !primitivesGroup->points.isEmpty();
+        const auto canBeShared = primitivesGroup->sourceObject->obtainSharingKey(sharingKey) && !isLabeledPolygon;
 
         //////////////////////////////////////////////////////////////////////////
         //if ((primitivesGroup->sourceObject->id >> 1) == 1937897178u)
@@ -1415,9 +1415,12 @@ void OsmAnd::MapPrimitiviser_P::obtainPrimitivesSymbols(
 
         const Stopwatch symbolsGroupsProcessingStopwatch(metric != nullptr);
 
+        // Allow displaying only captions for multi-labeled polygons
+        const bool canBeShownWithoutIcon = isLabeledPolygon && primitivesGroup->points.size() > 1;
+
         // Create a symbols group
         const std::shared_ptr<SymbolsGroup> group(new SymbolsGroup(
-            primitivesGroup->sourceObject));
+            primitivesGroup->sourceObject, canBeShownWithoutIcon));
 
         // For each primitive if primitive group, collect symbols from it
         collectSymbolsFromPrimitives(

--- a/src/Map/SymbolRasterizer.cpp
+++ b/src/Map/SymbolRasterizer.cpp
@@ -22,8 +22,10 @@ void OsmAnd::SymbolRasterizer::rasterize(
     _p->rasterize(symbolsGroups, mapPresentationEnvironment, outSymbolsGroups, filter, queryController);
 }
 
-OsmAnd::SymbolRasterizer::RasterizedSymbolsGroup::RasterizedSymbolsGroup(const std::shared_ptr<const MapObject>& mapObject_)
+OsmAnd::SymbolRasterizer::RasterizedSymbolsGroup::RasterizedSymbolsGroup(
+    const std::shared_ptr<const MapObject>& mapObject_, bool canBeShownWithoutIcon_ /* = false */)
     : mapObject(mapObject_)
+    , canBeShownWithoutIcon(canBeShownWithoutIcon_)
 {
 }
 

--- a/src/Map/SymbolRasterizer_P.cpp
+++ b/src/Map/SymbolRasterizer_P.cpp
@@ -65,7 +65,7 @@ void OsmAnd::SymbolRasterizer_P::rasterize(
 
         // Create group
         const std::shared_ptr<RasterizedSymbolsGroup> group(new RasterizedSymbolsGroup(
-            mapObject));
+            mapObject, symbolsGroup->canBeShownWithoutIcon));
 
         // Minimum and maximum offsets to allow column of symbols grow in both directions without overlapping
         // These offsets are computed only in case symbol is not on-path and not along-path


### PR DESCRIPTION
Still display polygon label when extra symbols are attached to the same polygon