### PR TITLE
Fix getGeoTiffData crash

### DIFF
--- a/src/GeoTiffCollection_P.cpp
+++ b/src/GeoTiffCollection_P.cpp
@@ -2,6 +2,7 @@
 #include "GeoTiffCollection.h"
 
 #include <cassert>
+#include <cmath>
 
 #include "ignore_warnings_on_external_includes.h"
 #include <gdal_priv.h>
@@ -17,6 +18,7 @@
 #include "Stopwatch.h"
 #include "Utilities.h"
 #include "Logging.h"
+#include "GeoTiffRasterWindow.h"
 
 #ifndef TIFF_NODATA
 #define TIFF_NODATA (-32768.0)
@@ -918,8 +920,8 @@ OsmAnd::GeoTiffCollection::CallResult OsmAnd::GeoTiffCollection_P::getGeoTiffDat
     // Composite tiles can be made up of data from multiple files
     QByteArray compositeTile;
     QByteArray compositeGCPList;
-    int compositeGCPCount;
-    int compositeSpecification;
+    int compositeGCPCount = 0;
+    int compositeSpecification = 0;
     PointD compositeOrigin;
     PointD compositeResolution;
     bool compose = false;
@@ -1052,6 +1054,18 @@ OsmAnd::GeoTiffCollection::CallResult OsmAnd::GeoTiffCollection_P::getGeoTiffDat
                 if (tileFound)
                 {
                     int specification;
+                    if (procParameters)
+                    {
+                        const auto hash = qHash(procParameters->colorsFilename);
+                        specification = *(reinterpret_cast<const int*>(&hash));
+                    }
+                    else
+                    {
+                        const auto hash = qHash(filePath);
+                        specification = *(reinterpret_cast<const int*>(&hash));
+                    }
+                    if (compose && !atLeastOnePresent)
+                        compositeSpecification = specification;
                     // Check one time if data is available in cache file
                     if (!cacheDatabase)
                     {
@@ -1068,8 +1082,6 @@ OsmAnd::GeoTiffCollection::CallResult OsmAnd::GeoTiffCollection_P::getGeoTiffDat
                                 default:
                                     cacheDatabase = hillshadeCache;
                             }
-                            const auto hash = qHash(procParameters->colorsFilename);
-                            specification = *(reinterpret_cast<const int*>(&hash));                        
                             if (cacheDatabase && cacheDatabase->isOpened() &&
                                 cacheDatabase->obtainTileData(tileId, zoom, specification, pBuffer))
                             {
@@ -1079,8 +1091,6 @@ OsmAnd::GeoTiffCollection::CallResult OsmAnd::GeoTiffCollection_P::getGeoTiffDat
                         else
                         {
                             cacheDatabase = heightmapCache;
-                            const auto hash = qHash(filePath);
-                            specification = *(reinterpret_cast<const int*>(&hash));
                             if (cacheDatabase && cacheDatabase->isOpened() &&
                                 cacheDatabase->obtainTileData(tileId, zoom, pBuffer, minValue, maxValue))
                             {
@@ -1122,205 +1132,173 @@ OsmAnd::GeoTiffCollection::CallResult OsmAnd::GeoTiffCollection_P::getGeoTiffDat
                                 upperLeft.y = qMax(upperLeft.y, 0.0);
                             lowerRight.x = (lowerRight.x - geoTransform[0]) / geoTransform[1];
                             lowerRight.y = (lowerRight.y - geoTransform[3]) / geoTransform[5];
-                            PointI dataOffset(std::floor(upperLeft.x), std::floor(upperLeft.y));
-                            PointI dataSize(
-                                static_cast<int32_t>(std::ceil(lowerRight.x)) - dataOffset.x,
-                                static_cast<int32_t>(std::ceil(lowerRight.y)) - dataOffset.y);
-                            PointI tileOffset(0, 0);
-                            PointI tileLength(tileSize, tileSize);
-                            const bool outRaster = dataOffset.x < 0 || dataOffset.y < 0 ||
-                                dataOffset.x + dataSize.x > tiffProperties.rasterSize.x ||
-                                dataOffset.y + dataSize.y > tiffProperties.rasterSize.y;
-                            if (outRaster)
+                            const auto tileSizeI = static_cast<int32_t>(qMin<uint32_t>(
+                                tileSize, static_cast<uint32_t>(std::numeric_limits<int32_t>::max())));
+                            GeoTiffRasterWindow::ClippedAxis clippedX;
+                            GeoTiffRasterWindow::ClippedAxis clippedY;
+                            const auto hasXData = GeoTiffRasterWindow::clipAxis(
+                                upperLeft.x, lowerRight.x, tiffProperties.rasterSize.x, tileSizeI, clippedX);
+                            const auto hasYData = GeoTiffRasterWindow::clipAxis(
+                                upperLeft.y, lowerRight.y, tiffProperties.rasterSize.y, tileSizeI, clippedY);
+                            PointI dataOffset(clippedX.dataOffset, clippedY.dataOffset);
+                            PointI dataSize(clippedX.dataSize, clippedY.dataSize);
+                            PointI tileOffset(clippedX.tileOffset, clippedY.tileOffset);
+                            PointI tileLength(clippedX.tileLength, clippedY.tileLength);
+                            upperLeft.x = clippedX.sourceStart;
+                            upperLeft.y = clippedY.sourceStart;
+                            lowerRight.x = clippedX.sourceEnd;
+                            lowerRight.y = clippedY.sourceEnd;
+                            empty = !hasXData || !hasYData;
+                            const bool readClipped = tileOffset.x > 0 || tileOffset.y > 0 ||
+                                tileLength.x != tileSizeI || tileLength.y != tileSizeI;
+                            if (!empty)
                             {
-                                const double resSize = tileSize;
-                                const PointD resFactor(
-                                    (lowerRight.x - upperLeft.x) / resSize,
-                                    (lowerRight.y - upperLeft.y) / resSize);
-                                tileOffset.x = std::ceil(qMax(-upperLeft.x, 0.0) / resFactor.x);
-                                tileOffset.y = std::ceil(qMax(-upperLeft.y, 0.0) / resFactor.y);
-                                if (tileOffset.x > 0)
+                                extraArg.dfXOff = upperLeft.x;
+                                extraArg.dfYOff = upperLeft.y;
+                                extraArg.dfXSize = lowerRight.x - upperLeft.x;
+                                extraArg.dfYSize = lowerRight.y - upperLeft.y;
+                                auto numOfBands = bandCount;
+                                auto dataType = destDataType;
+                                if (procParameters)
                                 {
-                                    tileLength.x -= tileOffset.x;
-                                    upperLeft.x += static_cast<double>(tileOffset.x) * resFactor.x;
-                                    dataOffset.x = std::floor(upperLeft.x);
-                                    dataSize.x = static_cast<int32_t>(std::ceil(lowerRight.x)) - dataOffset.x;
+                                    pByteBuffer = new char[valueCount * sizeof(float)];
+                                    numOfBands = 1;
+                                    dataType = GDT_Float32;
                                 }
-                                if (tileOffset.y > 0)
+                                const auto pixelSizeInBytes = dataType == GDT_Byte ? 1 : (dataType == GDT_Int16 ? 2 : 4);
+                                bandSize = valueCount * pixelSizeInBytes;
+                                auto pData = pByteBuffer;
+                                int pShift = readClipped ? (tileOffset.y * tileSize + tileOffset.x) * pixelSizeInBytes : 0;
+                                const auto side = tileSize * pixelSizeInBytes;
+                                for (int bandIndex = 1; bandIndex <= numOfBands; bandIndex++)
                                 {
-                                    tileLength.y -= tileOffset.y;
-                                    upperLeft.y += static_cast<double>(tileOffset.y) * resFactor.y;
-                                    dataOffset.y = std::floor(upperLeft.y);
-                                    dataSize.y = static_cast<int32_t>(std::ceil(lowerRight.y)) - dataOffset.y;
-                                }
-                                if (dataOffset.x + dataSize.x > tiffProperties.rasterSize.x)
-                                {
-                                    tileLength.x = tiffProperties.rasterSize.x - dataOffset.x;
-                                    tileLength.x = std::floor(static_cast<double>(tileLength.x) / resFactor.x);
-                                    lowerRight.x = upperLeft.x + static_cast<double>(tileLength.x) * resFactor.x;
-                                    dataSize.x = static_cast<int32_t>(std::ceil(lowerRight.x)) - dataOffset.x;
-                                    if (dataOffset.x + dataSize.x > tiffProperties.rasterSize.x)
-                                    {
-                                        dataSize.x--;
-                                        lowerRight.x = dataOffset.x + dataSize.x;
-                                    }
-                                }
-                                if (dataOffset.y + dataSize.y > tiffProperties.rasterSize.y)
-                                {
-                                    tileLength.y = tiffProperties.rasterSize.y - dataOffset.y;
-                                    tileLength.y = std::floor(static_cast<double>(tileLength.y) / resFactor.y);
-                                    lowerRight.y = upperLeft.y + static_cast<double>(tileLength.y) * resFactor.y;
-                                    dataSize.y = static_cast<int32_t>(std::ceil(lowerRight.y)) - dataOffset.y;
-                                    if (dataOffset.y + dataSize.y > tiffProperties.rasterSize.y)
-                                    {
-                                        dataSize.y--;
-                                        lowerRight.y = dataOffset.y + dataSize.y;
-                                    }
-                                }
-                            }
-                            extraArg.dfXOff = upperLeft.x;
-                            extraArg.dfYOff = upperLeft.y;
-                            extraArg.dfXSize = lowerRight.x - upperLeft.x;
-                            extraArg.dfYSize = lowerRight.y - upperLeft.y;
-                            auto numOfBands = bandCount;
-                            auto dataType = destDataType;
-                            if (procParameters)
-                            {
-                                pByteBuffer = new char[valueCount * sizeof(float)];
-                                numOfBands = 1;
-                                dataType = GDT_Float32;
-                            }
-                            const auto pixelSizeInBytes = dataType == GDT_Byte ? 1 : (dataType == GDT_Int16 ? 2 : 4);
-                            bandSize = valueCount * pixelSizeInBytes;
-                            auto pData = pByteBuffer;
-                            int pShift = outRaster ? (tileOffset.y * tileSize + tileOffset.x) * pixelSizeInBytes : 0;
-                            const auto side = tileSize * pixelSizeInBytes;
-                            for (int bandIndex = 1; bandIndex <= numOfBands; bandIndex++)
-                            {
-                                result = result && (band = dataset->GetRasterBand(bandIndex));
-                                result = result && band->GetRasterDataType() != GDT_Unknown;
-                                result = result && !band->GetColorTable();
-                                if (result)
-                                {
-                                    const auto bandNodata = band->GetNoDataValue();                                    
-                                    if (compose && bandNodata != noData)
-                                        result = false;
-                                    else
-                                        noData = bandNodata;
-                                }
-                                if (result && compose && outRaster)
-                                {
-                                    auto pValues = reinterpret_cast<float*>(pData);
-                                    std::fill(pValues, pValues + valueCount, static_cast<float>(noData));
-                                }
-                                result = result && band->RasterIO(GF_Read,
-                                    dataOffset.x, dataOffset.y,
-                                    dataSize.x, dataSize.y,
-                                    pData + pShift, tileLength.x, tileLength.y,
-                                    dataType, 0, side, &extraArg) == CE_None;
-                                if (!result) break;
-                                if (!procParameters)
-                                    getMinMaxValues(pData, dataType, noData, valueCount, minValue, maxValue);
-                                pData += bandSize;
-                            }
-                            if (result && tileSize > 1)
-                            {
-                                // Check values ​​in the center and corners to know that data is present
-                                const auto halfSize = tileSize >> 1;
-                                const auto middle = halfSize * halfSize * pixelSizeInBytes;
-                                if (!compose)
-                                {
-                                    result = isDataPresent(pByteBuffer + middle, dataType, noData);
-                                    result = result &&
-                                        isDataPresent(pByteBuffer, dataType, noData);
-                                    result = result &&
-                                        isDataPresent(pByteBuffer + side - pixelSizeInBytes, dataType, noData);
-                                    result = result &&
-                                        isDataPresent(pByteBuffer + bandSize - pixelSizeInBytes, dataType, noData);
-                                    result = result &&
-                                        isDataPresent(pByteBuffer + bandSize - side, dataType, noData);
-                                }
-                                // Check value in the center of top overscaled tile
-                                if (result && zoomShift > 0 && minZoom > MinZoomLevel)
-                                {
-                                    upperLeft = Utilities::metersFrom31(upperLeftOverscaled);
-                                    lowerRight = Utilities::metersFrom31(lowerRightOverscaled);
-                                    upperLeft.x = qMax((upperLeft.x - geoTransform[0]) / geoTransform[1], 0.0);
-                                    upperLeft.y = qMax((upperLeft.y - geoTransform[3]) / geoTransform[5], 0.0);
-                                    lowerRight.x = (lowerRight.x - geoTransform[0]) / geoTransform[1];
-                                    lowerRight.y = (lowerRight.y - geoTransform[3]) / geoTransform[5];
-                                    extraArg.dfXOff = (upperLeft.x + lowerRight.x) * 0.5;
-                                    extraArg.dfYOff = (upperLeft.y + lowerRight.y) * 0.5;
-                                    extraArg.dfXSize = 1.0;
-                                    extraArg.dfYSize = 1.0;
-                                    band = dataset->GetRasterBand(1);
-                                    double centerValue = noData;
-                                    result = band->RasterIO(GF_Read,
-                                        std::floor(extraArg.dfXOff), std::floor(extraArg.dfYOff),
-                                        1, 1, &centerValue, 1, 1, GDT_Float64, 0, 0, &extraArg) == CE_None;
-                                    result = result && centerValue != noData;
-                                }
-                                if (!result)
-                                    empty = true;
-                            }
-                            // Hillshade/slope/height raster processing
-                            if (procParameters)
-                            {
-                                if (compose)
-                                {
+                                    result = result && (band = dataset->GetRasterBand(bandIndex));
+                                    result = result && band->GetRasterDataType() != GDT_Unknown;
+                                    result = result && !band->GetColorTable();
                                     if (result)
                                     {
-                                        // Compensate height blur effect for much downsampled tiles
-                                        const float scaleFactor =
-                                            pow(1.5f, static_cast<float>(qMin(minZoom - zoom, 3))) - 0.2f;
-                                        
-                                        // Combine heightmap data
-                                        mergeHeights(tileSize, scaleFactor, !atLeastOnePresent,
-                                            compositeTile, reinterpret_cast<float*>(pByteBuffer));
-
-                                        if (!atLeastOnePresent)
+                                        const auto bandNodata = band->GetNoDataValue();
+                                        if (compose && bandNodata != noData)
+                                            result = false;
+                                        else
+                                            noData = bandNodata;
+                                    }
+                                    if (result && compose && readClipped)
+                                    {
+                                        auto pValues = reinterpret_cast<float*>(pData);
+                                        std::fill(pValues, pValues + valueCount, static_cast<float>(noData));
+                                    }
+                                    result = result && std::isfinite(extraArg.dfXSize) && extraArg.dfXSize > 0.0 &&
+                                        std::isfinite(extraArg.dfYSize) && extraArg.dfYSize > 0.0 &&
+                                        band->RasterIO(GF_Read,
+                                            dataOffset.x, dataOffset.y,
+                                            dataSize.x, dataSize.y,
+                                            pData + pShift, tileLength.x, tileLength.y,
+                                            dataType, 0, side, &extraArg) == CE_None;
+                                    if (!result) break;
+                                    if (!procParameters)
+                                        getMinMaxValues(pData, dataType, noData, valueCount, minValue, maxValue);
+                                    pData += bandSize;
+                                }
+                                if (result && tileSize > 1)
+                                {
+                                    // Check values ​​in the center and corners to know that data is present
+                                    const auto halfSize = tileSize >> 1;
+                                    const auto middle = halfSize * halfSize * pixelSizeInBytes;
+                                    if (!compose)
+                                    {
+                                        result = isDataPresent(pByteBuffer + middle, dataType, noData);
+                                        result = result &&
+                                            isDataPresent(pByteBuffer, dataType, noData);
+                                        result = result &&
+                                            isDataPresent(pByteBuffer + side - pixelSizeInBytes, dataType, noData);
+                                        result = result &&
+                                            isDataPresent(pByteBuffer + bandSize - pixelSizeInBytes, dataType, noData);
+                                        result = result &&
+                                            isDataPresent(pByteBuffer + bandSize - side, dataType, noData);
+                                    }
+                                    // Check value in the center of top overscaled tile
+                                    if (result && zoomShift > 0 && minZoom > MinZoomLevel)
+                                    {
+                                        upperLeft = Utilities::metersFrom31(upperLeftOverscaled);
+                                        lowerRight = Utilities::metersFrom31(lowerRightOverscaled);
+                                        upperLeft.x = qMax((upperLeft.x - geoTransform[0]) / geoTransform[1], 0.0);
+                                        upperLeft.y = qMax((upperLeft.y - geoTransform[3]) / geoTransform[5], 0.0);
+                                        lowerRight.x = (lowerRight.x - geoTransform[0]) / geoTransform[1];
+                                        lowerRight.y = (lowerRight.y - geoTransform[3]) / geoTransform[5];
+                                        extraArg.dfXOff = (upperLeft.x + lowerRight.x) * 0.5;
+                                        extraArg.dfYOff = (upperLeft.y + lowerRight.y) * 0.5;
+                                        extraArg.dfXSize = 1.0;
+                                        extraArg.dfYSize = 1.0;
+                                        band = dataset->GetRasterBand(1);
+                                        double centerValue = noData;
+                                        result = band->RasterIO(GF_Read,
+                                            std::floor(extraArg.dfXOff), std::floor(extraArg.dfYOff),
+                                            1, 1, &centerValue, 1, 1, GDT_Float64, 0, 0, &extraArg) == CE_None;
+                                        result = result && centerValue != noData;
+                                    }
+                                    if (!result)
+                                        empty = true;
+                                }
+                                // Hillshade/slope/height raster processing
+                                if (procParameters)
+                                {
+                                    if (compose)
+                                    {
+                                        if (result)
                                         {
-                                            compositeOrigin = tileOrigin;
-                                            compositeResolution = tileResolution;
-                                            compositeSpecification = specification;
-                                            compositeGCPCount = gcpCount;
-                                            compositeGCPList = QByteArray(
-                                                reinterpret_cast<const char*>(gcpList), sizeof(GDAL_GCP) * gcpCount);
-                                            atLeastOnePresent = true;
+                                            // Compensate height blur effect for much downsampled tiles
+                                            const float scaleFactor =
+                                                pow(1.5f, static_cast<float>(qMin(minZoom - zoom, 3))) - 0.2f;
+
+                                            // Combine heightmap data
+                                            mergeHeights(tileSize, scaleFactor, !atLeastOnePresent,
+                                                compositeTile, reinterpret_cast<float*>(pByteBuffer));
+
+                                            if (!atLeastOnePresent)
+                                            {
+                                                compositeOrigin = tileOrigin;
+                                                compositeResolution = tileResolution;
+                                                compositeSpecification = specification;
+                                                compositeGCPCount = gcpCount;
+                                                compositeGCPList = QByteArray(
+                                                    reinterpret_cast<const char*>(gcpList), sizeof(GDAL_GCP) * gcpCount);
+                                                atLeastOnePresent = true;
+                                            }
                                         }
+                                        else
+                                            incomplete = true;
                                     }
                                     else
-                                        incomplete = true;
+                                    {
+                                        // Produce hillshade/slope/height raster from heightmap data
+                                        result = result && destDataType == GDT_Byte && bandCount == 4 &&
+                                            postProcess(pByteBuffer, *procParameters, tileSize, overlap, tileOrigin,
+                                                tileResolution, gcpCount, gcpList, pBuffer);
+                                    }
+                                    delete[] pByteBuffer;
+                                    pByteBuffer = static_cast<char*>(pBuffer);
+                                    bandSize = (tileSize - overlap) * (tileSize - overlap) *
+                                        (destDataType == GDT_Byte ? 1 : (destDataType == GDT_Int16 ? 2 : 4));
                                 }
-                                else
+                                if (empty)
+                                    result = true;
+                                // Put raster data in cache database file
+                                if (result && !empty && !compose && cacheDatabase && cacheDatabase->isOpened())
                                 {
-                                    // Produce hillshade/slope/height raster from heightmap data
-                                    result = result && destDataType == GDT_Byte && bandCount == 4 &&
-                                        postProcess(pByteBuffer, *procParameters, tileSize, overlap, tileOrigin,
-                                            tileResolution, gcpCount, gcpList, pBuffer);                                
-                                }
-                                delete[] pByteBuffer;
-                                pByteBuffer = static_cast<char*>(pBuffer);
-                                bandSize = (tileSize - overlap) * (tileSize - overlap) *
-                                    (destDataType == GDT_Byte ? 1 : (destDataType == GDT_Int16 ? 2 : 4));
-                            }
-                            if (empty)
-                                result = true;
-                            // Put raster data in cache database file
-                            if (result && !empty && !compose && cacheDatabase && cacheDatabase->isOpened())
-                            {
-                                const auto currentTime = QDateTime::currentMSecsSinceEpoch();
-                                if (!procParameters && minValue != std::numeric_limits<float>::max()
-                                    && maxValue != std::numeric_limits<float>::lowest())
-                                {
-                                    cacheDatabase->storeTileData(tileId, zoom, specification,
-                                        QByteArray::fromRawData(pByteBuffer, bandCount * bandSize),
-                                        currentTime, 0, minValue, maxValue);
-                                }
-                                else
-                                {
-                                    cacheDatabase->storeTileData(tileId, zoom, specification,
-                                        QByteArray::fromRawData(pByteBuffer, bandCount * bandSize), currentTime);
+                                    const auto currentTime = QDateTime::currentMSecsSinceEpoch();
+                                    if (!procParameters && minValue != std::numeric_limits<float>::max()
+                                        && maxValue != std::numeric_limits<float>::lowest())
+                                    {
+                                        cacheDatabase->storeTileData(tileId, zoom, specification,
+                                            QByteArray::fromRawData(pByteBuffer, bandCount * bandSize),
+                                            currentTime, 0, minValue, maxValue);
+                                    }
+                                    else
+                                    {
+                                        cacheDatabase->storeTileData(tileId, zoom, specification,
+                                            QByteArray::fromRawData(pByteBuffer, bandCount * bandSize), currentTime);
+                                    }
                                 }
                             }
                         }
@@ -1341,6 +1319,9 @@ OsmAnd::GeoTiffCollection::CallResult OsmAnd::GeoTiffCollection_P::getGeoTiffDat
     // Build result composite tile and put it in cache
     if (compose && available && destDataType == GDT_Byte && bandCount == 4)
     {
+        const auto outputTileSize = tileSize > overlap ? tileSize - overlap : 0;
+        const auto outputPixelSizeInBytes = destDataType == GDT_Byte ? 1 : (destDataType == GDT_Int16 ? 2 : 4);
+        const auto outputBandSize = outputTileSize * outputTileSize * outputPixelSizeInBytes;
         bool result = true;
         if (atLeastOnePresent)
         {
@@ -1356,13 +1337,13 @@ OsmAnd::GeoTiffCollection::CallResult OsmAnd::GeoTiffCollection_P::getGeoTiffDat
         else
         {
             // Produce empty raster if no data was found
-            memset(pBuffer, bandCount * bandSize, 0);
+            memset(pBuffer, 0, bandCount * outputBandSize);
         }
         if (result && !incomplete && cacheDatabase && cacheDatabase->isOpened())
         {
             const auto currentTime = QDateTime::currentMSecsSinceEpoch();
             cacheDatabase->storeTileData(tileId, zoom, compositeSpecification,
-                QByteArray::fromRawData(pByteBuffer, bandCount * bandSize), currentTime);
+                QByteArray::fromRawData(pByteBuffer, bandCount * outputBandSize), currentTime);
         }
         if (result)
             return GeoTiffCollection::CallResult::Completed;
@@ -1434,4 +1415,3 @@ bool OsmAnd::GeoTiffCollection_P::calculateHeights(
     }
     return true;
 }
-

--- a/src/GeoTiffRasterWindow.h
+++ b/src/GeoTiffRasterWindow.h
@@ -1,0 +1,83 @@
+#ifndef _OSMAND_CORE_GEOTIFF_RASTER_WINDOW_H_
+#define _OSMAND_CORE_GEOTIFF_RASTER_WINDOW_H_
+
+#include <cmath>
+#include <cstdint>
+
+#include <QtGlobal>
+
+namespace OsmAnd
+{
+    namespace GeoTiffRasterWindow
+    {
+        struct ClippedAxis
+        {
+            int32_t dataOffset = 0;
+            int32_t dataSize = 0;
+            int32_t tileOffset = 0;
+            int32_t tileLength = 0;
+            double sourceStart = 0.0;
+            double sourceEnd = 0.0;
+        };
+
+        inline bool clipAxis(
+            const double sourceStart,
+            const double sourceEnd,
+            const int32_t sourceLimit,
+            const int32_t tileLimit,
+            ClippedAxis& out)
+        {
+            out = ClippedAxis();
+            if (sourceLimit <= 0 || tileLimit <= 0 ||
+                !std::isfinite(sourceStart) || !std::isfinite(sourceEnd))
+                return false;
+
+            const auto sourceSpan = sourceEnd - sourceStart;
+            if (!std::isfinite(sourceSpan) || sourceSpan <= 0.0)
+                return false;
+
+            const auto sourceResolution = sourceSpan / static_cast<double>(tileLimit);
+            if (!std::isfinite(sourceResolution) || sourceResolution <= 0.0)
+                return false;
+
+            const auto clampToTile = [tileLimit](const double value) -> int32_t
+            {
+                if (!std::isfinite(value) || value >= static_cast<double>(tileLimit))
+                    return tileLimit;
+                if (value <= 0.0)
+                    return 0;
+                return static_cast<int32_t>(value);
+            };
+
+            int32_t destStart = 0;
+            int32_t destEnd = tileLimit;
+            if (sourceStart < 0.0)
+                destStart = clampToTile(std::ceil(-sourceStart / sourceResolution));
+            if (sourceEnd > static_cast<double>(sourceLimit))
+                destEnd = clampToTile(std::floor((static_cast<double>(sourceLimit) - sourceStart) /
+                    sourceResolution));
+
+            destStart = qBound<int32_t>(0, destStart, tileLimit);
+            destEnd = qBound<int32_t>(destStart, destEnd, tileLimit);
+            out.tileOffset = destStart;
+            out.tileLength = destEnd - destStart;
+            if (out.tileLength <= 0)
+                return false;
+
+            out.sourceStart = sourceStart + static_cast<double>(destStart) * sourceResolution;
+            out.sourceEnd = sourceStart + static_cast<double>(destEnd) * sourceResolution;
+            if (!std::isfinite(out.sourceStart) || !std::isfinite(out.sourceEnd) ||
+                out.sourceEnd <= out.sourceStart)
+                return false;
+
+            out.dataOffset = qBound<int32_t>(
+                0, static_cast<int32_t>(std::floor(out.sourceStart)), sourceLimit);
+            const auto dataEnd = qBound<int32_t>(
+                0, static_cast<int32_t>(std::ceil(out.sourceEnd)), sourceLimit);
+            out.dataSize = dataEnd - out.dataOffset;
+            return out.dataSize > 0;
+        }
+    }
+}
+
+#endif // !defined(_OSMAND_CORE_GEOTIFF_RASTER_WINDOW_H_)

--- a/tests/OsmAndCoreTests.qbs
+++ b/tests/OsmAndCoreTests.qbs
@@ -4,7 +4,8 @@ Project {
     name: "Tests"
     references: [
         "unit/TestAddressSearch.qbs",
-        "unit/TestCoordinateSearch.qbs"
+        "unit/TestCoordinateSearch.qbs",
+        "unit/TestGeoTiffRasterWindow.qbs"
 	]
     qbsSearchPaths: "qbs"
     AutotestRunner { }

--- a/tests/unit/TestGeoTiffRasterWindow.cpp
+++ b/tests/unit/TestGeoTiffRasterWindow.cpp
@@ -1,0 +1,102 @@
+#include "../../src/GeoTiffRasterWindow.h"
+
+#include <QtTest/QtTest>
+
+#include <limits>
+
+using OsmAnd::GeoTiffRasterWindow::ClippedAxis;
+using OsmAnd::GeoTiffRasterWindow::clipAxis;
+
+class TestGeoTiffRasterWindow : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void keepsInteriorWindow();
+    void clipsStartEdge();
+    void clipsEndEdge();
+    void clipsCornerWindow();
+    void rejectsEmptySourceIntersection();
+    void rejectsInvalidWindows();
+};
+
+void TestGeoTiffRasterWindow::keepsInteriorWindow()
+{
+    ClippedAxis axis;
+
+    QVERIFY(clipAxis(10.0, 20.0, 100, 256, axis));
+    QCOMPARE(axis.dataOffset, 10);
+    QCOMPARE(axis.dataSize, 10);
+    QCOMPARE(axis.tileOffset, 0);
+    QCOMPARE(axis.tileLength, 256);
+    QCOMPARE(axis.sourceStart, 10.0);
+    QCOMPARE(axis.sourceEnd, 20.0);
+}
+
+void TestGeoTiffRasterWindow::clipsStartEdge()
+{
+    ClippedAxis axis;
+
+    QVERIFY(clipAxis(-2.0, 6.0, 10, 8, axis));
+    QCOMPARE(axis.dataOffset, 0);
+    QCOMPARE(axis.dataSize, 6);
+    QCOMPARE(axis.tileOffset, 2);
+    QCOMPARE(axis.tileLength, 6);
+    QCOMPARE(axis.sourceStart, 0.0);
+    QCOMPARE(axis.sourceEnd, 6.0);
+}
+
+void TestGeoTiffRasterWindow::clipsEndEdge()
+{
+    ClippedAxis axis;
+
+    QVERIFY(clipAxis(4.0, 12.0, 10, 8, axis));
+    QCOMPARE(axis.dataOffset, 4);
+    QCOMPARE(axis.dataSize, 6);
+    QCOMPARE(axis.tileOffset, 0);
+    QCOMPARE(axis.tileLength, 6);
+    QCOMPARE(axis.sourceStart, 4.0);
+    QCOMPARE(axis.sourceEnd, 10.0);
+}
+
+void TestGeoTiffRasterWindow::clipsCornerWindow()
+{
+    ClippedAxis xAxis;
+    ClippedAxis yAxis;
+
+    QVERIFY(clipAxis(-2.0, 6.0, 10, 8, xAxis));
+    QVERIFY(clipAxis(4.0, 12.0, 10, 8, yAxis));
+
+    QCOMPARE(xAxis.tileOffset, 2);
+    QCOMPARE(xAxis.tileLength, 6);
+    QCOMPARE(xAxis.tileOffset + xAxis.tileLength, 8);
+    QCOMPARE(yAxis.tileOffset, 0);
+    QCOMPARE(yAxis.tileLength, 6);
+    QCOMPARE(yAxis.tileOffset + yAxis.tileLength, 6);
+    QVERIFY(xAxis.dataOffset >= 0);
+    QVERIFY(xAxis.dataOffset + xAxis.dataSize <= 10);
+    QVERIFY(yAxis.dataOffset >= 0);
+    QVERIFY(yAxis.dataOffset + yAxis.dataSize <= 10);
+}
+
+void TestGeoTiffRasterWindow::rejectsEmptySourceIntersection()
+{
+    ClippedAxis axis;
+
+    QVERIFY(!clipAxis(-10.0, -2.0, 10, 8, axis));
+    QVERIFY(!clipAxis(12.0, 20.0, 10, 8, axis));
+}
+
+void TestGeoTiffRasterWindow::rejectsInvalidWindows()
+{
+    ClippedAxis axis;
+    const auto infinity = std::numeric_limits<double>::infinity();
+
+    QVERIFY(!clipAxis(5.0, 5.0, 10, 8, axis));
+    QVERIFY(!clipAxis(0.0, 10.0, 0, 8, axis));
+    QVERIFY(!clipAxis(0.0, 10.0, 10, 0, axis));
+    QVERIFY(!clipAxis(infinity, 10.0, 10, 8, axis));
+}
+
+QTEST_MAIN(TestGeoTiffRasterWindow)
+#include "TestGeoTiffRasterWindow.moc"

--- a/tests/unit/TestGeoTiffRasterWindow.qbs
+++ b/tests/unit/TestGeoTiffRasterWindow.qbs
@@ -1,0 +1,7 @@
+import qbs
+import "UnitTest.qbs" as UnitTest
+
+UnitTest {
+    name: "TestGeoTiffRasterWindow"
+    files: ["TestGeoTiffRasterWindow.cpp"]
+}


### PR DESCRIPTION
# Fix GeoTIFF Height Raster Crash

**Summary**
- The crash on April 18, 2026 is caused by terrain/height raster rendering, not the GPX nearest-city search threads also visible in the report.
- Crashing stack: `GDALCopyWordsFromT<unsigned char>` → `GTiffRasterBand::IRasterIO` → `GeoTiffCollection_P::getGeoTiffData` → `HeightRasterMapLayerProvider_P::obtainData`.
- The risky call is in [/Users/crimean/osmand/core/src/GeoTiffCollection_P.cpp](/Users/crimean/osmand/core/src/GeoTiffCollection_P.cpp):1216, where a clipped GeoTIFF read window is passed to GDAL without final validation that the destination offset/length still fits the allocated tile buffer.

**Fix**
- In [/Users/crimean/osmand/core/src/GeoTiffCollection_P.cpp](/Users/crimean/osmand/core/src/GeoTiffCollection_P.cpp), harden the `outRaster` clipping before `band->RasterIO(...)`:
  - Validate finite positive `resFactor.x/y` and `extraArg.dfXSize/dfYSize`.
  - Clamp `tileOffset.x/y` to `[0, tileSize]`.
  - Clamp `tileLength.x/y` so `tileOffset + tileLength <= tileSize`.
  - Clamp `dataOffset/dataSize` so the source window stays inside `tiffProperties.rasterSize`.
  - If the clipped source or destination window is empty, skip `RasterIO` and treat that file/tile as empty instead of failed.
- Fix the nearby empty-composite-tile bug at [/Users/crimean/osmand/core/src/GeoTiffCollection_P.cpp](/Users/crimean/osmand/core/src/GeoTiffCollection_P.cpp):1359:
  - Replace the reversed `memset(pBuffer, bandCount * bandSize, 0)` with a zero-fill using an explicitly computed output size: `(tileSize - overlap) * (tileSize - overlap) * bandCount * bytesPerSample`.
  - Do not rely on `bandSize` there unless it has been initialized on all paths.
- Leave GPX/search code unchanged; those threads are unrelated to the triggered crash.

**Changed:**

- Hardened the clipped RasterIO window in GeoTiffCollection_P.cpp (line 1133):
  - finite/positive source span and GDAL floating window checks
  - clamped source offsets/sizes to the TIFF raster bounds
  - clamped destination offsets/lengths to the allocated tile buffer
  - empty clipped windows now skip RasterIO instead of failing or writing out of bounds
- Added the reusable clipping helper in GeoTiffRasterWindow.h (line 23).
- Fixed the empty composite tile zero-fill bug in GeoTiffCollection_P.cpp (line 1320), replacing the reversed memset with an explicit output size.
- Added regression coverage for interior, edge, corner, empty, and invalid windows in TestGeoTiffRasterWindow.cpp (line 23) and wired it into OsmAndCoreTests.qbs (line 4).
