### PR TITLE
Sync iOS readStreet() X/Y calculation with Java city24 (24 bit)

### DIFF
--- a/src/Data/ObfAddressSectionReader_P.cpp
+++ b/src/Data/ObfAddressSectionReader_P.cpp
@@ -450,21 +450,13 @@ void OsmAnd::ObfAddressSectionReader_P::readStreet(
             case OBF::StreetIndex::kXFieldNumber:
             {
                 const auto d24 = ObfReaderUtilities::readSInt32(cis);
-                position31.x = streetGroup->position31.x;
-                if (d24 > 0)
-                    position31.x += (static_cast<uint32_t>(d24) << 7);
-                else if (d24 < 0)
-                    position31.x -= (static_cast<uint32_t>(-d24) << 7);
+                position31.x = ((streetGroup->position31.x >> 7) + d24) << 7;
                 break;
             }
             case OBF::StreetIndex::kYFieldNumber:
             {
                 const auto d24 = ObfReaderUtilities::readSInt32(cis);
-                position31.y = streetGroup->position31.y;
-                if (d24 > 0)
-                    position31.y += (static_cast<uint32_t>(d24) << 7);
-                else if (d24 < 0)
-                    position31.y -= (static_cast<uint32_t>(-d24) << 7);
+                position31.y = ((streetGroup->position31.y >> 7) + d24) << 7;
                 break;
             }
             case OBF::StreetIndex::kIdFieldNumber:


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd/issues/11345

Java code uses `>> 7` (high bits strip) for city24 X/Y to calculate the offset:

```
readStreet(s, null, loadBuildings, x >> 7, y >> 7, city.isPostcode() ? city.getName() : null,

readStreet(s, null, false, MapUtils.get31TileNumberX(l.getLongitude()) >> 7, MapUtils.get31TileNumberY(l.getLatitude()) >> 7, obj.isPostcode() ? obj.getName() : null, reg.attributeTagsTable);
```

This request equalizes resultant X/Y after readStreet() with Java. In addition, it fixes the unequal distance for each street in a set of the same street placed in a different streetGroup. In turn, this fixes the DISTANCE_COMPARATOR of GeocodingUtilities, which requires the same distance for street(s) that are located in different streetGroup.

