### PR TITLE
fix losing matcherMode value

### DIFF
--- a/src/Data/ObfPoiSectionReader_P.cpp
+++ b/src/Data/ObfPoiSectionReader_P.cpp
@@ -494,6 +494,7 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenities(
                         poiAdditionalFilter,
                         visitor,
                         queryController,
+                        StringMatcherMode::CHECK_STARTS_FROM_SPACE,
                         tagGroups);
 
                     if (tilesToSkip && zoomFilter != InvalidZoomLevel && atLeastOneAccepted)
@@ -840,6 +841,7 @@ bool OsmAnd::ObfPoiSectionReader_P::readAmenitiesDataBox(
     const QPair<int, int>* poiAdditionalFilter,
     const ObfPoiSectionReader::VisitorFunction visitor,
     const std::shared_ptr<const IQueryController>& queryController,
+    const StringMatcherMode matcherMode,
     const TagGroupsMap& tagGroups)
 {
     const auto cis = reader.getCodedInputStream().get();
@@ -911,6 +913,7 @@ bool OsmAnd::ObfPoiSectionReader_P::readAmenitiesDataBox(
                     section,
                     amenity,
                     query,
+                    matcherMode,
                     tileId,
                     zoom,
                     bbox31,
@@ -971,6 +974,7 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
     const std::shared_ptr<const ObfPoiSectionInfo>& section,
     std::shared_ptr<const Amenity>& outAmenity,
     const QString& query,
+    const StringMatcherMode matcherMode,
     const TileId boxTileId,
     const ZoomLevel boxZoom,
     const AreaI* const bbox31,
@@ -996,7 +1000,7 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenity(
     QList<QPair<int, QVariant>> stringOrDataValues;
     QHash<uint32_t, QList<QPair<QString, QString>>> tagGroupsAmenity;
     auto categoriesFilterChecked = false;
-    const CollatorStringMatcher matcher(query, StringMatcherMode::CHECK_STARTS_FROM_SPACE);
+    const CollatorStringMatcher matcher(query, matcherMode);
     uint32_t precisionXY = 0;
     bool hasSubcategoriesField = false;
     bool topIndexAdditonalFound = false;
@@ -1424,6 +1428,7 @@ void OsmAnd::ObfPoiSectionReader_P::readAmenitiesByName(
                         poiAdditionalFilter,
                         visitor,
                         queryController,
+                        matcherMode,
                         tagGroups);
 
                     ObfReaderUtilities::ensureAllDataWasRead(cis);

--- a/src/Data/ObfPoiSectionReader_P.h
+++ b/src/Data/ObfPoiSectionReader_P.h
@@ -154,12 +154,14 @@ namespace OsmAnd
             const QPair<int, int>* poiAdditionalFilter,
             const ObfPoiSectionReader::VisitorFunction visitor,
             const std::shared_ptr<const IQueryController>& queryController,
+            const StringMatcherMode matcherMode,
             const TagGroupsMap& tagGroups);
         static void readAmenity(
             const ObfReader_P& reader,
             const std::shared_ptr<const ObfPoiSectionInfo>& section,
             std::shared_ptr<const Amenity>& outAmenity,
             const QString& query,
+            const StringMatcherMode matcherMode,
             const TileId boxTileId,
             const ZoomLevel boxZoom,
             const AreaI* const bbox31,

--- a/src/ICU.cpp
+++ b/src/ICU.cpp
@@ -674,6 +674,8 @@ OSMAND_CORE_API bool OSMAND_CORE_CALL OsmAnd::ICU::cmatches(const QString& _base
             return cstartsWith(_base, _part, true, false, false);
         case StringMatcherMode::CHECK_EQUALS:
             return cstartsWith(_base, _part, false, false, true);
+        case StringMatcherMode::MULTISEARCH:
+            return cstartsWith(_part, _base, true, true, true);
         default:
             return false;
     }


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd-iOS/issues/4499#issuecomment-4874472872)

test point: 50.44832 30.49468

before:

<img width="1136" height="912" alt="Screenshot 2026-07-07 at 19 57 02" src="https://github.com/user-attachments/assets/686f83d5-899f-46b2-af3e-1cc43e9f1cdf" />

after:

<img width="1136" height="912" alt="Screenshot 2026-07-07 at 22 08 57" src="https://github.com/user-attachments/assets/6a10bfe8-5309-4250-9473-da5600d059b2" />


android app to compare:

<img width="422" height="937" alt="Screenshot 2026-07-07 at 20 05 56" src="https://github.com/user-attachments/assets/0a50d9b2-20b9-4459-b0db-ff7d5c1fcf15" />


---

synced this android code:

<img width="1681" height="455" alt="Screenshot 2026-07-07 at 19 43 26" src="https://github.com/user-attachments/assets/3d21cdf6-ef6b-4c8e-aeed-8d53d11444e7" />

---

<img width="1668" height="967" alt="Screenshot 2026-07-07 at 19 49 06" src="https://github.com/user-attachments/assets/f8575a10-81c2-44f3-8cd5-3a56e7cbc725" />
