### PR TITLE
Improve reverse geocoding performance with area filtering

### DIFF
--- a/src/Search/ReverseGeocoder_P.cpp
+++ b/src/Search/ReverseGeocoder_P.cpp
@@ -188,6 +188,7 @@ QVector<std::shared_ptr<const OsmAnd::ReverseGeocoder::ResultEntry>> OsmAnd::Rev
         criteria.strictMatch = true;
         criteria.streetGroupTypesMask = ObfAddressStreetGroupTypesMask().set(ObfAddressStreetGroupType::CityOrTown);
         criteria.bbox31 = Nullable<AreaI>((AreaI)Utilities::boundingBox31FromAreaInMeters(DISTANCE_STREET_NAME_PROXIMITY_BY_NAME, *road->searchPoint31()));
+        criteria.obfInfoAreaFilter = criteria.bbox31;
         addressByNameSearch->performSearch(
                     criteria,
                     [&streetList, addCommonWords, streetNamesUsed, road](const OsmAnd::ISearch::Criteria& criteria,


### PR DESCRIPTION
## Problem

Reverse geocoding could become very slow when a large number of OBF files were installed.

`ReverseGeocoder` already calculated a 15 km bounding box for the street search, but this bounding box was only applied while reading address data. It was not passed as `obfInfoAreaFilter`, so `AddressesByNameSearch` created readers for every OBF containing address data, including geographically unrelated files.

On the affected iOS device, 921 installed OBF files caused address resolution to take about 15 seconds.

## Solution

Pass the existing street-search bounding box as `obfInfoAreaFilter` to `AddressesByNameSearch`.

This filters OBF files by their address section bounds before the search begins.

The change does not modify:

- The 15 km search radius
- Street and building matching
- Result ordering
- Address formatting
- The public API

## Android impact

Android currently uses its Java-based reverse geocoding implementation and already filters map readers by location and available address data. Therefore, this change does not affect the current Android reverse geocoding flow.