### PR TITLE
diacriticsAndAlignCharsFix

### DIFF
--- a/include/OsmAndCore/CollatorStringMatcher.h
+++ b/include/OsmAndCore/CollatorStringMatcher.h
@@ -33,7 +33,6 @@ namespace OsmAnd
         static bool cstartsWith(const QString& _searchInParam, const QString& _theStart,
                          bool checkBeginning, bool checkSpaces, bool equals);
         static QString lowercaseAndAlignChars(const QString& fullText);
-        static QString alignChars(const QString& fullText);
     };
 }
 

--- a/src/CollatorStringMatcher.cpp
+++ b/src/CollatorStringMatcher.cpp
@@ -38,8 +38,6 @@ bool OsmAnd::CollatorStringMatcher::cmatches(const QString& _base, const QString
 
 bool OsmAnd::CollatorStringMatcher::cmatches(const QString& _base, const QString& _part, bool alignPart, StringMatcherMode _mode)
 {
-    
-    
     QString base = _base;
     if (!_base.isNull() && _base.indexOf('-') != -1)
     {
@@ -52,7 +50,7 @@ bool OsmAnd::CollatorStringMatcher::cmatches(const QString& _base, const QString
     QString part = _part;
     if (alignPart)
     {
-        part = alignChars(part);
+        part = OsmAnd::SearchAlgorithms::alignChars(part);
     }
     base = lowercaseAndAlignChars(_base);
     return OsmAnd::ICU::cmatches(base, part, _mode);
@@ -72,9 +70,4 @@ bool OsmAnd::CollatorStringMatcher::cstartsWith(const QString& _searchInParam, c
 QString OsmAnd::CollatorStringMatcher::lowercaseAndAlignChars(const QString& fullText)
 {
     return CollatorStringMatcher_P::lowercaseAndAlignChars(fullText);
-}
-
-QString OsmAnd::CollatorStringMatcher::alignChars(const QString& fullText)
-{
-    return CollatorStringMatcher_P::alignChars(fullText);
 }

--- a/src/CollatorStringMatcher_P.cpp
+++ b/src/CollatorStringMatcher_P.cpp
@@ -35,18 +35,5 @@ QString OsmAnd::CollatorStringMatcher_P::lowercaseAndAlignChars(const QString& f
 {
     QLocale defaultLocale;
     QString res = defaultLocale.toLower(fullText);
-    return alignChars(res);
-}
-
-QString OsmAnd::CollatorStringMatcher_P::alignChars(const QString& fullText)
-{
-    QString normalized = fullText;
-    if (ArabicNormalizer::isSpecialArabic(fullText))
-    {
-        normalized = ArabicNormalizer::normalize(fullText);
-        normalized = normalized == "" ? fullText : normalized;
-    }
-    normalized = SearchAlgorithms::removeApostrophes(normalized);
-    normalized = SearchAlgorithms::replaceGermanSS(normalized);
-    return normalized;
+    return OsmAnd::SearchAlgorithms::alignChars(res);
 }

--- a/src/CollatorStringMatcher_P.h
+++ b/src/CollatorStringMatcher_P.h
@@ -16,7 +16,6 @@ namespace OsmAnd
     {
     private:
         static QString lowercaseAndAlignChars(const QString& fullText);
-        static QString alignChars(const QString& fullText);
     protected:
         CollatorStringMatcher_P(CollatorStringMatcher* const owner);
         

--- a/src/ICU.cpp
+++ b/src/ICU.cpp
@@ -731,6 +731,11 @@ OSMAND_CORE_API bool OSMAND_CORE_CALL OsmAnd::ICU::ccontains(const QString& _bas
 OSMAND_CORE_API bool OSMAND_CORE_CALL OsmAnd::ICU::cstartsWith(const QString& _searchInParam, const QString& _theStart,
                                                   bool checkBeginning, bool checkSpaces, bool equals)
 {
+    // Normalize before acquiring icuResourcesLock: alignChars() calls stripDiacritics(),
+    // which acquires the same non-recursive lock.
+    QString searchInParam = OsmAnd::CollatorStringMatcher::lowercaseAndAlignChars(_searchInParam);
+    QString theStartParam = OsmAnd::SearchAlgorithms::alignChars(_theStart);
+
     UErrorCode icuError = U_ZERO_ERROR;
     bool result = false;
     QReadLocker icuReadLocker(&icuResourcesLock);
@@ -746,8 +751,6 @@ OSMAND_CORE_API bool OSMAND_CORE_CALL OsmAnd::ICU::cstartsWith(const QString& _s
     {
         // FUTURE: This is not effective code, it runs on each comparision
         // It would be more efficient to normalize all strings in file and normalize search string before collator
-        QString searchInParam = OsmAnd::CollatorStringMatcher::lowercaseAndAlignChars(_searchInParam);
-        QString theStartParam = OsmAnd::SearchAlgorithms::alignChars(_theStart);
         UnicodeString searchIn = qStrToUniStr(searchInParam.replace("-", " "));
         UnicodeString theStart = qStrToUniStr(theStartParam.replace("-", " "));
 

--- a/src/ICU.cpp
+++ b/src/ICU.cpp
@@ -1,6 +1,7 @@
 #include "ICU.h"
 #include "ICU_private.h"
 #include "CollatorStringMatcher.h"
+#include "SearchAlgorithms.h"
 
 #include <cassert>
 #include <cstring>
@@ -8,6 +9,7 @@
 #include "QtExtensions.h"
 #include "ignore_warnings_on_external_includes.h"
 #include <QByteArray>
+#include <QStringList>
 #include <QVector>
 #include <QThread>
 #include <QHash>
@@ -203,10 +205,12 @@ bool OsmAnd::ICU::initialize()
 
     Collator *collator = nullptr;
     icuError = U_ZERO_ERROR;
+    
+    // romanian locale encounters diacritics as different symbols
     Locale locale = Locale::getDefault();
-    if (std::strcmp(locale.getLanguage(), "ro") ||
-        std::strcmp(locale.getLanguage(), "cs") ||
-        std::strcmp(locale.getLanguage(), "sk"))
+    if (std::strcmp(locale.getLanguage(), "ro") == 0 ||
+        std::strcmp(locale.getLanguage(), "cs") == 0 ||
+        std::strcmp(locale.getLanguage(), "sk") == 0)
     {
         collator = Collator::createInstance(Locale("en", "US"), icuError);
     }
@@ -739,7 +743,7 @@ OSMAND_CORE_API bool OSMAND_CORE_CALL OsmAnd::ICU::cstartsWith(const QString& _s
         // FUTURE: This is not effective code, it runs on each comparision
         // It would be more efficient to normalize all strings in file and normalize search string before collator
         QString searchInParam = OsmAnd::CollatorStringMatcher::lowercaseAndAlignChars(_searchInParam);
-        QString theStartParam = OsmAnd::CollatorStringMatcher::alignChars(_theStart);
+        QString theStartParam = OsmAnd::SearchAlgorithms::alignChars(_theStart);
         UnicodeString searchIn = qStrToUniStr(searchInParam.replace("-", " "));
         UnicodeString theStart = qStrToUniStr(theStartParam.replace("-", " "));
 

--- a/src/ICU.cpp
+++ b/src/ICU.cpp
@@ -14,6 +14,7 @@
 #include <QThread>
 #include <QHash>
 #include <QReadWriteLock>
+#include <QLocale>
 #include "restore_internal_warnings.h"
 
 #include "ignore_warnings_on_external_includes.h"
@@ -205,9 +206,12 @@ bool OsmAnd::ICU::initialize()
 
     Collator *collator = nullptr;
     icuError = U_ZERO_ERROR;
-    
+
     // romanian locale encounters diacritics as different symbols
-    Locale locale = Locale::getDefault();
+    QLocale qtLocale;
+    const QByteArray localeName = qtLocale.name().toLatin1();
+    Locale locale = Locale::createCanonical(localeName.constData());
+
     if (std::strcmp(locale.getLanguage(), "ro") == 0 ||
         std::strcmp(locale.getLanguage(), "cs") == 0 ||
         std::strcmp(locale.getLanguage(), "sk") == 0)
@@ -216,7 +220,7 @@ bool OsmAnd::ICU::initialize()
     }
     else
     {
-        collator = Collator::createInstance(icuError);
+        collator = Collator::createInstance(locale, icuError);
     }
     
     if (U_FAILURE(icuError))


### PR DESCRIPTION
[issue](https://github.com/osmandapp/web/issues/1510#issuecomment-5248846755)
[related ios request](https://github.com/osmandapp/OsmAnd-iOS/pull/5651)

---

Testicn coordinates and phrases:

```
50.6230 26.2488

Київська вулиця

Киівська вулиця
```

---

before:

<img width="300"  alt="Screenshot 2026-08-14 at 15 52 45" src="https://github.com/user-attachments/assets/075f6917-59e2-4f39-811d-90a9c0110926" />  <img width="300" alt="Screenshot 2026-08-14 at 15 52 54" src="https://github.com/user-attachments/assets/3fc4731d-57a8-4563-89d5-43f540656f75" />


---
after:

<img width="300"  alt="Screenshot 2026-08-14 at 15 38 12" src="https://github.com/user-attachments/assets/0988f8d7-a2b8-40df-8067-917dc0b3b24d" />  <img width="300" alt="Screenshot 2026-08-14 at 15 38 23" src="https://github.com/user-attachments/assets/92795f17-95c3-4bd1-81ae-dc250fc64b96" />

---


code changes:

Added alignChars() normalization in collator  like in android:

<img alt="Screenshot 2026-08-14 at 19 07 34" src="https://github.com/user-attachments/assets/6d24c509-9bae-46cc-a2e7-719892dfea2a" />


<img  alt="Screenshot 2026-08-14 at 15 36 33" src="https://github.com/user-attachments/assets/19d72217-cc6c-4c41-9ac4-5d28685064f8" />

---

Use everywhere new alignChars() version from OsmAnd::SearchAlgorithms.
Delete old version from CollatorStringMatcher_P.

<img  alt="Screenshot 2026-08-14 at 15 31 57" src="https://github.com/user-attachments/assets/3d7496a2-a174-4fcf-9832-4f1805d34cf5" />

---

Bugfix. 
Android logic: if locale is Roman return US collator. 
IOS logic vas inverted. Because  std::strcmp() returns 0 if strings are qual. Not 1.

<img alt="Screenshot 2026-08-14 at 19 10 19" src="https://github.com/user-attachments/assets/8eeb2af2-7373-4703-bb40-8e54d8ff9e2b" />

<img alt="Screenshot 2026-08-14 at 18 48 54" src="https://github.com/user-attachments/assets/2da7087a-9e39-473a-98a5-dff77d89257a" />


---

Test passed:

<img width="373" height="232" alt="Screenshot 2026-08-14 at 19 03 00" src="https://github.com/user-attachments/assets/cdee5ef7-2086-4463-9648-81c4f31129e6" />
