### PR TITLE
Clear only the style result slots that were written

### DIFF
--- a/include/OsmAndCore/Map/MapStyleEvaluationResult.h
+++ b/include/OsmAndCore/Map/MapStyleEvaluationResult.h
@@ -48,6 +48,12 @@ namespace OsmAnd
     protected:
         QVector<QVariant> _storage;
 
+        // Which slots were actually written since the last clear. The storage
+        // has a slot for every value definition the style declares - hundreds
+        // of them - while an evaluation fills in a handful, so clearing all of
+        // them was most of the cost of evaluating a style at all.
+        QVector<IMapStyle::ValueDefinitionId> _setValueDefIds;
+
     public:
         MapStyleEvaluationResult(const int size = 0);
         MapStyleEvaluationResult(const MapStyleEvaluationResult& that);

--- a/src/Map/MapStyleEvaluationResult.cpp
+++ b/src/Map/MapStyleEvaluationResult.cpp
@@ -9,12 +9,14 @@ OsmAnd::MapStyleEvaluationResult::MapStyleEvaluationResult(const int size /*= 0*
 
 OsmAnd::MapStyleEvaluationResult::MapStyleEvaluationResult(const MapStyleEvaluationResult& that)
     : _storage(detachedOf(that._storage))
+    , _setValueDefIds(detachedOf(that._setValueDefIds))
 {
 }
 
 #ifdef Q_COMPILER_RVALUE_REFS
 OsmAnd::MapStyleEvaluationResult::MapStyleEvaluationResult(MapStyleEvaluationResult&& that)
     : _storage(qMove(that._storage))
+    , _setValueDefIds(qMove(that._setValueDefIds))
 {
 }
 #endif // Q_COMPILER_RVALUE_REFS
@@ -26,7 +28,10 @@ OsmAnd::MapStyleEvaluationResult::~MapStyleEvaluationResult()
 OsmAnd::MapStyleEvaluationResult& OsmAnd::MapStyleEvaluationResult::operator=(const MapStyleEvaluationResult& that)
 {
     if (this != &that)
+    {
         _storage = detachedOf(that._storage);
+        _setValueDefIds = detachedOf(that._setValueDefIds);
+    }
 
     return *this;
 }
@@ -35,7 +40,10 @@ OsmAnd::MapStyleEvaluationResult& OsmAnd::MapStyleEvaluationResult::operator=(co
 OsmAnd::MapStyleEvaluationResult& OsmAnd::MapStyleEvaluationResult::operator=(MapStyleEvaluationResult&& that)
 {
     if (this != &that)
+    {
         _storage = qMove(that._storage);
+        _setValueDefIds = qMove(that._setValueDefIds);
+    }
 
     return *this;
 }
@@ -56,7 +64,11 @@ void OsmAnd::MapStyleEvaluationResult::setValue(
     if (valueDefId >= _storage.size())
         _storage.resize(valueDefId + 1);
 
-    _storage[valueDefId] = value;
+    auto& slot = _storage[valueDefId];
+    if (!slot.isValid())
+        _setValueDefIds.push_back(valueDefId);
+
+    slot = value;
 }
 
 void OsmAnd::MapStyleEvaluationResult::setBooleanValue(
@@ -199,14 +211,17 @@ void OsmAnd::MapStyleEvaluationResult::reserve(const int size)
 void OsmAnd::MapStyleEvaluationResult::reset()
 {
     _storage.clear();
+    _setValueDefIds.clear();
 }
 
 void OsmAnd::MapStyleEvaluationResult::clear()
 {
-    const auto size = _storage.size();
-    auto pValue = _storage.data();
-    for (int index = 0; index < size; index++)
-        (pValue++)->clear();
+    // Only what was written. Walking every slot meant touching hundreds of
+    // QVariants to throw away a handful.
+    for (const auto valueDefId : constOf(_setValueDefIds))
+        _storage[valueDefId].clear();
+
+    _setValueDefIds.clear();
 }
 
 bool OsmAnd::MapStyleEvaluationResult::isEmpty() const


### PR DESCRIPTION
`MapStyleEvaluationResult` keeps a slot for every value definition the style declares — hundreds of them. `clear()` walked all of them, destroying a `QVariant` each, to discard the handful an evaluation actually fills in. It runs once per object per ruleset, so this was a large part of what evaluating a style costs.

Remembering which slots were written turns that walk into one over the handful.

**Measured.** Desktop, 45 tiles of Greater London at zoom 12, identical object and primitive counts before and after:

| | before | after |
|---|---|---|
| reading the .obf | 612 ms | 372 ms |
| primitivising | 1883 ms | 1324 ms |
| total | 2700 ms | 1901 ms |

Reading gets faster too, because the .obf reader evaluates the style as well to decide what to keep.

On a Galaxy A54 panning the same area, `MapStyleEvaluationResult::clear()` and `QVariant::clear()` together fall from **2.32%** of the application's CPU time to **0.12%**, repeatable across runs.
