### PR TITLE
Fix SIGSEGV in WeatherTileResourceProvider_P::obtainGeoTile when geo tiles database is missing

### DIFF
--- a/src/Map/WeatherTileResourceProvider_P.cpp
+++ b/src/Map/WeatherTileResourceProvider_P.cpp
@@ -290,7 +290,7 @@ bool OsmAnd::WeatherTileResourceProvider_P::obtainGeoTileTime(
         int64_t& outTime)
 {
     auto geoDb = getGeoTilesDatabase();
-    if (geoDb->isOpened())
+    if (geoDb && geoDb->isOpened())
     {
         geoDb->obtainTileTime(tileId, zoom, outTime, dateTime);
         return true;
@@ -321,7 +321,7 @@ int64_t OsmAnd::WeatherTileResourceProvider_P::obtainGeoTile(
         withLock = preLockGeoTile(tileId, zoom);
 
     auto geoDb = getGeoTilesDatabase();
-    if (geoDb->isOpened())
+    if (geoDb && geoDb->isOpened())
     {
         int64_t timestamp = 0;
         const auto currentTime = QDateTime::currentMSecsSinceEpoch();
@@ -578,20 +578,34 @@ void OsmAnd::WeatherTileResourceProvider_P::downloadGeoTilesAsync(
 
 std::shared_ptr<OsmAnd::TileSqliteDatabase> OsmAnd::WeatherTileResourceProvider_P::getGeoTilesDatabase()
 {
-    QReadLocker geoScopedLocker(&_geoDbLock);
-    
-    auto currentWeatherSource = getWeatherSource();
-    const auto citGeoDb = _geoTilesDbMap.constFind(currentWeatherSource);
-    if (citGeoDb != _geoTilesDbMap.cend())
-        return *citGeoDb;
-    
-    return nullptr;
+    auto currentWeatherSource = getStorageWeatherSource();
+
+    {
+        QReadLocker geoScopedLocker(&_geoDbLock);
+
+        const auto citGeoDb = _geoTilesDbMap.constFind(currentWeatherSource);
+        if (citGeoDb != _geoTilesDbMap.cend())
+            return *citGeoDb;
+    }
+    {
+        QWriteLocker geoScopedLocker(&_geoDbLock);
+
+        const auto citGeoDb = _geoTilesDbMap.constFind(currentWeatherSource);
+        if (citGeoDb != _geoTilesDbMap.cend())
+            return *citGeoDb;
+
+        auto db = createGeoTilesDatabase(currentWeatherSource);
+        if (db)
+            _geoTilesDbMap.insert(currentWeatherSource, db);
+
+        return db;
+    }
 }
 
 std::shared_ptr<OsmAnd::TileSqliteDatabase> OsmAnd::WeatherTileResourceProvider_P::getRasterTilesDatabase(
     BandIndex band)
 {
-    auto currentWeatherSource = getWeatherSource();
+    auto currentWeatherSource = getStorageWeatherSource();
     auto key = QPair<WeatherSource, BandIndex>(currentWeatherSource, band);
     
     {
@@ -620,7 +634,7 @@ bool OsmAnd::WeatherTileResourceProvider_P::isEmpty()
 {
     QWriteLocker geoScopedLocker(&_geoDbLock);
     
-    auto currentWeatherSource = getWeatherSource();
+    auto currentWeatherSource = getStorageWeatherSource();
     const auto citGeoDb = _geoTilesDbMap.constFind(currentWeatherSource);
     if (citGeoDb != _geoTilesDbMap.cend())
         return (*citGeoDb)->isEmpty();
@@ -1686,5 +1700,20 @@ QString OsmAnd::WeatherTileResourceProvider_P::getWeatherSourcePrefix(WeatherSou
             return QStringLiteral("ecmwf_");
         default:
             return QStringLiteral("gfs_");
+    }
+}
+
+OsmAnd::WeatherSource OsmAnd::WeatherTileResourceProvider_P::getStorageWeatherSource() const
+{
+    // Keep in sync with getWeatherSourcePrefix(): every source that shares a cache file prefix
+    // has to share the very same database instance, so unknown sources fall back to GFS
+    const auto weatherSource = getWeatherSource();
+    switch (weatherSource)
+    {
+        case WeatherSource::GFS:
+        case WeatherSource::ECMWF:
+            return weatherSource;
+        default:
+            return WeatherSource::GFS;
     }
 }

--- a/src/Map/WeatherTileResourceProvider_P.h
+++ b/src/Map/WeatherTileResourceProvider_P.h
@@ -232,6 +232,7 @@ namespace OsmAnd
         
         QString getWeatherTilesUrlPrefix() const;
         QString getWeatherSourcePrefix(WeatherSource weatherSource) const;
+        WeatherSource getStorageWeatherSource() const;
 
         int getCurrentRequestVersion() const;
         int getAndUpdateRequestVersion(


### PR DESCRIPTION
Fixes osmandapp/OsmAnd#25778.

### Problem

With the weather plugin enabled and no weather data downloaded, the OpenGL renderer crashes with a native `SIGSEGV` on a Qt thread-pool thread within about a minute of panning the map:

```
Cause: null pointer dereference (fault addr 0x8)
#00 OsmAnd::TileSqliteDatabase::isOpened() const+0
#01 OsmAnd::WeatherTileResourceProvider_P::obtainGeoTile(...)+1632
#02 OsmAnd::WeatherTileResourceProvider_P::ObtainTileTask::run()+1060
...
#07 OsmAnd::GeoTileObjectsProvider_P::obtainData(...)+2420
```

`getGeoTilesDatabase()` can return `nullptr`, but `obtainGeoTile()` and `obtainGeoTileTime()` called `isOpened()` on the result unguarded. All other call sites — `importTileData()`, `calculateTilesSize()`, `removeTileDataBefore()`, `removeTileData()`, `closeProvider()`, and every `getRasterTilesDatabase()` use — already check for null.

This is a regression from 55f5799 ("Use separate weather_tiffs.db"), which replaced the always-non-null `_geoTilesDb` member with a `QHash<WeatherSource, ...>` lookup and added null checks to the other call sites, but not to these two.

There are two ways the lookup comes back empty:

1. The constructor fills the map eagerly and inserts only on a successful `open()`, with no later retry. A single failed open — cache directory removed between manager creation and lazy provider construction, read-only filesystem, no free space — leaves the source without a database for the rest of the session, and every subsequent `obtainGeoTile()` crashes. Raster databases are unaffected because `getRasterTilesDatabase()` creates them on demand.
2. `WeatherSource::Undefined` is part of the public enum and is handled explicitly elsewhere (`WeatherRasterLayerProvider.cpp:53`). `getWeatherSourcePrefix()` maps unknown sources to `gfs_`, but the map lookup used the raw enum value, which was never inserted.

### Changes

* Guard both dereferences with `if (geoDb && geoDb->isOpened())`. `obtainGeoTile()` already falls through to `unlockGeoTile()` and returns `-1` for empty data, so lock bookkeeping and the caller contract are unchanged.
* Create geo databases lazily in `getGeoTilesDatabase()`, using the same read-lock / write-lock / double-check shape as `getRasterTilesDatabase()`, so a failed open can recover. No call site holds `_geoDbLock` while calling it — all of them acquire it afterwards — so the read-to-write upgrade introduces no deadlock. The eager creation in the constructor is kept, it is just no longer the only chance.
* Add `getStorageWeatherSource()`, which resolves anything other than GFS/ECMWF to GFS, and use it for the geo and raster database map keys and in `isEmpty()`. Without it, lazy creation would open a second `TileSqliteDatabase` over the same `gfs_*.db` file for `Undefined`.

### Testing

`WeatherTileResourceProvider_P.cpp` compiles cleanly for `aarch64-none-linux-android21` with the project's own flags; only the two warnings that were already present in the file remain.