### PR TITLE
Fix 3D track rendering without heightmap resources

### DIFF
--- a/src/Map/VectorLine_P.cpp
+++ b/src/Map/VectorLine_P.cpp
@@ -1349,7 +1349,7 @@ bool OsmAnd::VectorLine_P::generatePrimitive(
     const auto cellsPerTileSize =
         _hasElevationDataResources ? (AtlasMapRenderer::HeixelsPerTileSide - 1) / (1 << (zoomLevel - _mapZoomLevel))
         // Use selective granularity to avoid collisions with the surface
-        : (_flatEarth ? 0 : (_mapZoomLevel < 3 ? 4 : (_mapZoomLevel < 6 ? 2 : 1)));
+        : (_flatEarth ? (withHeights ? 1 : 0) : (_mapZoomLevel < 3 ? 4 : (_mapZoomLevel < 6 ? 2 : 1)));
     bool tesselated = true;
 
     const auto startPos = PointD(startPoint);


### PR DESCRIPTION
## Summary
- keep real tile subdivision for elevated vector lines on flat maps when heightmap resources are unavailable
- preserve the zero-cell optimization for vector lines without per-point heights

## Root cause
The zero-cell path groups geometry under the sentinel tile (-1, -1). The renderer later normalizes that sentinel and uses it for meters-per-unit interpolation. For lines with per-point heights, such as tracks visualized by speed, this can produce invalid negative elevation scaling and place the track below the surface.

Using one grid cell for elevated lines restores valid tile metadata and the behavior from before the spherical-vector-symbol regression, without changing ordinary 2D lines.

Fixes osmandapp/OsmAnd#24942


## Follow-up
Defects found in the same code paths while reviewing this change are tracked separately in osmandapp/OsmAnd#25851 — items 1-7 are pre-existing, items 8-9 are performance costs introduced here. None of them block this fix.
