### PR TITLE
GPUAPI_OpenGL2plus: initialize GLEW in experimental mode

### DIFF
--- a/src/Map/OpenGL/OpenGL2plus/GPUAPI_OpenGL2plus.cpp
+++ b/src/Map/OpenGL/OpenGL2plus/GPUAPI_OpenGL2plus.cpp
@@ -90,6 +90,11 @@ bool OsmAnd::GPUAPI_OpenGL2plus::initialize()
     if (!ok)
         return false;
 
+    // GLEW is linked statically into every module that uses it, so this copy of its state is
+    // distinct from the host application's. In an OpenGL core profile glGetString(GL_EXTENSIONS)
+    // is unavailable, and without the experimental flag glewInit() leaves most function pointers
+    // NULL even though it reports success (crashes on macOS CGL core-profile contexts).
+    glewExperimental = GL_TRUE;
     if (glewInit() != GLEW_NO_ERROR)
         return false;
     // Silence OpenGL error here, it's inside GLEW, so it's not ours


### PR DESCRIPTION
GLEW is linked statically into every module that uses it, so `OsmAndCore` holds its own copy of
GLEW's function-pointer table, separate from the host application's. In an OpenGL **core profile**
`glGetString(GL_EXTENSIONS)` is unavailable, and without `glewExperimental` `glewInit()` reports
success while leaving most pointers NULL. The first GL call through one of them jumps to address 0.

Reproduced on macOS with the `eyepiece` tool. It sets `glewExperimental` in *its own* copy of GLEW
before creating the context, so the context is fine and the crash lands inside core instead, right
after `Map renderer will use N concurrent worker(s)`:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x0000000000000000
error: memory read failed for 0x0
```

No unwindable stack, because the jump target is the null pointer itself. With this flag set,
`eyepiece` renders normally on a 4.1 core-profile CGL context.

Setting `glewExperimental = GL_TRUE` before `glewInit()` is the documented way to use GLEW with a
core profile and is what GLEW's own documentation recommends; it should be harmless on the platforms
that were already working.

Related internal task: OsmAnd-Issues#3313 (`bird` on new macOS). `bird` itself is unaffected — it
runs on a legacy 2.1 context where the extension string is available — but it shares the same macOS
GL toolchain work.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Build the OsmAnd v2 (OpenGL) renderer on macOS so a rendering change could be proven with local images instead of an emulator.
2. After several build failures, keep going until `eyepiece` actually rendered.
3. Later, open this as a separate pull request in OsmAnd-core, linked to the internal task.

Decided by the agent, not requested explicitly:
- Diagnosed the crash as GLEW's per-module state rather than a context problem, and chose to set the flag inside core rather than work around it in the tool.
- Wrote the explanatory comment above the call.
