### PR TITLE
MapRasterizer: let a line offset ramp along its length (hmargin_end)

### DIFF
--- a/include/OsmAndCore/Map/MapStyleBuiltinValueDefinitions_Set.h
+++ b/include/OsmAndCore/Map/MapStyleBuiltinValueDefinitions_Set.h
@@ -87,6 +87,7 @@ DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_EFFECT__2, Output, String, "pathEffect__2",
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_CAP__2, Output, String, "cap__2", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_JOIN__2, Output, String, "join__2", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN__2, Output, Float, "hmargin__2", true)
+DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_END__2, Output, Float, "hmargin_end__2", true)
 
 // - Layer_minus1
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_COLOR__1, Output, Color, "color__1", false)
@@ -95,6 +96,7 @@ DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_EFFECT__1, Output, String, "pathEffect__1",
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_CAP__1, Output, String, "cap__1", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_JOIN__1, Output, String, "join__1", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN__1, Output, Float, "hmargin__1", true)
+DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_END__1, Output, Float, "hmargin_end__1", true)
 
 // - Layer_0
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_COLOR_0, Output, Color, "color_0", false)
@@ -103,6 +105,7 @@ DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_EFFECT_0, Output, String, "pathEffect_0", f
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_CAP_0, Output, String, "cap_0", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_JOIN_0, Output, String, "join_0", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_0, Output, Float, "hmargin_0", true)
+DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_END_0, Output, Float, "hmargin_end_0", true)
 
 // - Layer_1
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_COLOR, Output, Color, "color", false)
@@ -111,6 +114,7 @@ DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_EFFECT, Output, String, "pathEffect", false
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_CAP, Output, String, "cap", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_JOIN, Output, String, "join", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN, Output, Float, "hmargin", true)
+DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_END, Output, Float, "hmargin_end", true)
 
 // - Layer_2
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_COLOR_2, Output, Color, "color_2", false)
@@ -119,6 +123,7 @@ DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_EFFECT_2, Output, String, "pathEffect_2", f
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_CAP_2, Output, String, "cap_2", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_JOIN_2, Output, String, "join_2", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_2, Output, Float, "hmargin_2", true)
+DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_END_2, Output, Float, "hmargin_end_2", true)
 
 // - Layer_3
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_COLOR_3, Output, Color, "color_3", false)
@@ -127,6 +132,7 @@ DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_EFFECT_3, Output, String, "pathEffect_3", f
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_CAP_3, Output, String, "cap_3", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_JOIN_3, Output, String, "join_3", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_3, Output, Float, "hmargin_3", true)
+DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_END_3, Output, Float, "hmargin_end_3", true)
 
 // - Layer_4
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_COLOR_4, Output, Color, "color_4", false)
@@ -135,6 +141,7 @@ DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_EFFECT_4, Output, String, "pathEffect_4", f
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_CAP_4, Output, String, "cap_4", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_JOIN_4, Output, String, "join_4", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_4, Output, Float, "hmargin_4", true)
+DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_END_4, Output, Float, "hmargin_end_4", true)
 
 // - Layer_5
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_COLOR_5, Output, Color, "color_5", false)
@@ -143,6 +150,7 @@ DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_EFFECT_5, Output, String, "pathEffect_5", f
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_CAP_5, Output, String, "cap_5", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_JOIN_5, Output, String, "join_5", false)
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_5, Output, Float, "hmargin_5", true)
+DECLARE_BUILTIN_VALUEDEF(OUTPUT_PATH_HMARGIN_END_5, Output, Float, "hmargin_end_5", true)
 
 DECLARE_BUILTIN_VALUEDEF(OUTPUT_SHADER, Output, String, "shader", false)
 

--- a/src/Map/MapRasterizer_P.cpp
+++ b/src/Map/MapRasterizer_P.cpp
@@ -507,11 +507,17 @@ bool OsmAnd::MapRasterizer_P::calculateLinePath(
     const QVector<PointI>& points31,
     const AreaI& area31,
     SkPath& outPath,
-    float offset = 0.0f) const
+    float offset = 0.0f,
+    float offsetEnd = 0.0f) const
 {
-    bool rightShift = offset > 0;
-    offset = abs(offset);
-    bool hasShift = offset > 0;
+    // The offset ramps from `offset` to `offsetEnd` along the line, which is how a route slides
+    // between lanes where it joins or leaves a bundle instead of jumping sideways. With the two
+    // equal the offset is constant, as it was before.
+    const bool hasShift = offset != 0.0f || offsetEnd != 0.0f;
+    const float totalLength = hasShift && offset != offsetEnd
+        ? polylineLengthInPixels(context, points31)
+        : 0.0f;
+    float travelled = 0.0f;
 
     bool intersect = false;
     int pointIdx = 0;
@@ -551,11 +557,22 @@ bool OsmAnd::MapRasterizer_P::calculateLinePath(
                 simplifyVertexToDirection(context, vertex, pVertex, tempVertex);
                 if (hasShift)
                 {
-                    auto normal = Utilities::computeNormalToLine(pVertex, vertex, rightShift);
-                    auto addition = normal * offset;
-                    auto p1 = pVertex + addition;
+                    const auto segmentLength = (vertex - pVertex).norm();
+                    const auto shiftAt = [&](float distance) -> float
+                    {
+                        if (totalLength <= 0.0f)
+                            return offset;
+                        const auto t = qBound(0.0f, distance / totalLength, 1.0f);
+                        return offset + (offsetEnd - offset) * t;
+                    };
+                    const auto shiftStart = shiftAt(travelled);
+                    const auto shiftEnd = shiftAt(travelled + segmentLength);
+
+                    auto normal = Utilities::computeNormalToLine(pVertex, vertex, shiftStart > 0.0f);
+                    auto p1 = pVertex + normal * qAbs(shiftStart);
                     outPath.moveTo(p1.x, p1.y);
-                    auto p2 = tempVertex + addition;
+                    normal = Utilities::computeNormalToLine(pVertex, vertex, shiftEnd > 0.0f);
+                    auto p2 = tempVertex + normal * qAbs(shiftEnd);
                     outPath.lineTo(p2.x, p2.y);
                 }
                 else
@@ -565,11 +582,34 @@ bool OsmAnd::MapRasterizer_P::calculateLinePath(
                 intersect = true;
             }
         }
+        if (pointIdx > 0)
+        {
+            travelled += (vertex - pVertex).norm();
+        }
         prevCross = cross;
         pVertex = vertex;
     }
 
     return intersect;
+}
+
+float OsmAnd::MapRasterizer_P::polylineLengthInPixels(
+    const Context& context,
+    const QVector<PointI>& points31) const
+{
+    float length = 0.0f;
+    PointF vertex;
+    PointF previous;
+    for (int idx = 0; idx < points31.size(); idx++)
+    {
+        calculateVertex(context, points31[idx], vertex);
+        if (idx > 0)
+        {
+            length += (vertex - previous).norm();
+        }
+        previous = vertex;
+    }
+    return length;
 }
 
 void OsmAnd::MapRasterizer_P::drawLineLayer(
@@ -581,15 +621,19 @@ void OsmAnd::MapRasterizer_P::drawLineLayer(
     const QVector<PointI>& points31,
     const std::shared_ptr<const MapPrimitiviser::Primitive>& primitive,
     const PaintValuesSet valueSetSelector,
-    const IMapStyle::ValueDefinitionId hMarginId)
+    const IMapStyle::ValueDefinitionId hMarginId,
+    const IMapStyle::ValueDefinitionId hMarginEndId)
 {
     if (updatePaint(context, paint, primitive, valueSetSelector, false))
     {
         float hMargin = 0.0f;
         if (primitive->evaluationResult.getFloatValue(hMarginId, hMargin))
         {
+            float hMarginEnd = hMargin;
+            primitive->evaluationResult.getFloatValue(hMarginEndId, hMarginEnd);
+
             SkPath newPath;
-            if (calculateLinePath(context, points31, area31, newPath, hMargin))
+            if (calculateLinePath(context, points31, area31, newPath, hMargin, hMarginEnd))
                 canvas.drawPath(newPath, paint);
         }
         else
@@ -679,28 +723,36 @@ void OsmAnd::MapRasterizer_P::rasterizePolyline(
     else
     {
         drawLineLayer(canvas, paint, path, context, enlargedArea31, points31, primitive, PaintValuesSet::Layer_minus2,
-                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN__2);
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN__2,
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_END__2);
 
         drawLineLayer(canvas, paint, path, context, enlargedArea31, points31, primitive, PaintValuesSet::Layer_minus1,
-                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN__1);
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN__1,
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_END__1);
 
         drawLineLayer(canvas, paint, path, context, enlargedArea31, points31, primitive, PaintValuesSet::Layer_0,
-                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_0);
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_0,
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_END_0);
 
         drawLineLayer(canvas, paint, path, context, enlargedArea31, points31, primitive, PaintValuesSet::Layer_1,
-                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN);
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN,
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_END);
 
         drawLineLayer(canvas, paint, path, context, enlargedArea31, points31, primitive, PaintValuesSet::Layer_2,
-                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_2);
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_2,
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_END_2);
 
         drawLineLayer(canvas, paint, path, context, enlargedArea31, points31, primitive, PaintValuesSet::Layer_3,
-                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_3);
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_3,
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_END_3);
 
         drawLineLayer(canvas, paint, path, context, enlargedArea31, points31, primitive, PaintValuesSet::Layer_4,
-                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_4);
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_4,
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_END_4);
 
         drawLineLayer(canvas, paint, path, context, enlargedArea31, points31, primitive, PaintValuesSet::Layer_5,
-                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_5);
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_5,
+                      env->styleBuiltinValueDefs->id_OUTPUT_PATH_HMARGIN_END_5);
 
         rasterizePolylineIcons(context, canvas, path, primitive->evaluationResult);
     }

--- a/src/Map/MapRasterizer_P.h
+++ b/src/Map/MapRasterizer_P.h
@@ -124,13 +124,19 @@ namespace OsmAnd
             const QVector<PointI>& points31,
             const std::shared_ptr<const MapPrimitiviser::Primitive>& primitive,
             const PaintValuesSet valueSetSelector,
-            const IMapStyle::ValueDefinitionId hMarginId);
+            const IMapStyle::ValueDefinitionId hMarginId,
+            const IMapStyle::ValueDefinitionId hMarginEndId);
+        float polylineLengthInPixels(
+            const Context& context,
+            const QVector<PointI>& points31) const;
+
         bool calculateLinePath(
             const Context& context,
             const QVector<PointI>& points31,
             const AreaI& area31,
             SkPath& outPath,
-            float offset) const;
+            float offset,
+            float offsetEnd) const;
         inline void calculateVertex(const Context& context, const PointI& point31, PointF& vertex) const;
         inline float lineEquation(float x1, float y1, float x2, float y2, float x) const;
         inline void simplifyVertexToDirection(const Context& , const PointF& , const PointF& , PointF&) const;


### PR DESCRIPTION
Draft — part of parallel route lanes (OsmAnd-Issues#3110). Not for merge on its own; the generator
side that produces the lane tags is a separate draft in OsmAnd-tools.

## What

`hmargin` displaces a line by a constant number of pixels. That is enough to draw routes sharing a
path as parallel lanes, but not to move a route *between* lanes: wherever it joins or leaves a bundle
the line jumps sideways, which reads as a break.

This adds `hmargin_end` beside every `hmargin` layer. When it differs from `hmargin`, the offset is
interpolated along the line by cumulative pixel length, so the route slides across over its own
length — the "unbraiding" printed trail maps do at junctions.

```
<apply_if additional="route_lane=2"     hmargin="7"/>
<apply_if additional="route_lane_end=0" hmargin_end="0"/>
```

The two attributes are independent, so a style needs one table per lane value rather than one per
pair — 2n rules instead of n².

## Compatibility

With `hmargin_end` absent it defaults to `hmargin`, `offset == offsetEnd`, and the code takes the
same constant-offset path as before. Verified with eyepiece:

- `hmargin=0, hmargin_end=0` renders **identically** to no offset at all (bit-for-bit).
- `hmargin=12, hmargin_end=120` differs from a constant 12 over **9%** of the frame — the ramp is
  doing something.
- `hmargin=12, hmargin_end=12` differs from a plain `hmargin=12` only over 1.2% of the frame, and the
  differing pixels are where shields land, not on the route lines; the values reaching the rasterizer
  are identical (`start=24.000000 end=24.000000` in both).

Renders are deterministic — two identical runs are bit-for-bit equal — so those comparisons mean what
they say.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Investigate how to draw overlapping hiking and cycling routes side by side instead of stacked.
2. After per-way lane assignment made routes hop sideways, choose between a stable lane per route, leaving it as is, or a centred bundle with a smooth transition — picked the centred bundle with transitions, noting it needs core work.
3. Later: open this as a draft pull request and attach it to the tracker task.

Decided by the agent, not requested explicitly:
- Adding `hmargin_end` for all eight line layers rather than only the main one.
- Interpolating by cumulative pixel length rather than by vertex index.
- Keeping the old behaviour bit-identical when the two values are equal, and measuring that rather than assuming it.
