### PR TITLE
EyePiece: wait for a confirmed idle before reading a frame, and -noSymbols

### DIFF
--- a/tools/include/OsmAndCoreTools/EyePiece.h
+++ b/tools/include/OsmAndCoreTools/EyePiece.h
@@ -70,6 +70,7 @@ namespace OsmAndTools
             float mapScale;
             float symbolsScale;
             QString locale;
+            bool noSymbols = false;
             bool verbose = false;
 #if defined(OSMAND_TARGET_OS_linux)
             bool useLegacyContext;

--- a/tools/src/EyePiece.cpp
+++ b/tools/src/EyePiece.cpp
@@ -5,6 +5,7 @@
 #include <iomanip>
 #include <limits>
 #include <QRegularExpression>
+#include <QThread>
 #include <OsmAndCore/restore_internal_warnings.h>
 
 #include <OsmAndCore.h>
@@ -1029,7 +1030,8 @@ bool OsmAndTools::EyePiece::rasterize(std::ostream& output)
         // Add providers
         if (configuration.verbose)
             output << xT("Adding providers to map renderer...") << std::endl;
-        mapRenderer->addSymbolsProvider(binaryMapStaticSymbolProvider);
+        if (!configuration.noSymbols)
+            mapRenderer->addSymbolsProvider(binaryMapStaticSymbolProvider);
         mapRenderer->setMapLayerProvider(0, binaryMapRasterTileProvider);
 
         if (configuration.geotiffCollection)
@@ -1116,9 +1118,14 @@ bool OsmAndTools::EyePiece::rasterize(std::ostream& output)
         int tileZoom = 0;
         int64_t tileX = 0;
         int64_t tileY = 0;
+        // How many times in a row the renderer has to report idle before the frame is read back
+        const auto idleConfirmationsRequired = 3u;
+        const auto idleConfirmationIntervalMs = 10u;
+        auto idleConfirmations = 0u;
         for (;; framesCounter++)
         {
             frameStopwatch.start();
+            idleConfirmations = 0;
             if (tilesMode)
             {
                 QString line;
@@ -1170,9 +1177,20 @@ bool OsmAndTools::EyePiece::rasterize(std::ostream& output)
                 glFlush();
                 glVerifyResult(output);
 
-                // Check if map renderer finished processing
+                // Check if map renderer finished processing. One idle poll is not enough: right
+                // after a target change there is a window where the state has been applied but the
+                // resource requests of the new location are not registered yet, and the renderer
+                // reports idle while the frame still holds nothing but the background. Rendering a
+                // list of scattered tiles hits that window often enough to write blank tiles, so
+                // idle has to hold over several polls before the frame is taken.
                 if (mapRenderer->isIdle())
-                    break;
+                {
+                    if (++idleConfirmations >= idleConfirmationsRequired)
+                        break;
+                    QThread::msleep(idleConfirmationIntervalMs);
+                }
+                else
+                    idleConfirmations = 0;
 
                 // In tiles mode the run is a list of independent tiles, so the limit is per tile
                 if ((tilesMode ? frameStopwatch : renderingStopwatch).elapsed() > (10 * 60 /* 10 minutes */))
@@ -1969,6 +1987,10 @@ bool OsmAndTools::EyePiece::Configuration::parseFromCommandLineArguments(
                 outError = QString("'%1' can not be parsed as tile size in pixels").arg(value);
                 return false;
             }
+        }
+        else if (arg == QLatin1String("-noSymbols"))
+        {
+            outConfiguration.noSymbols = true;
         }
         else if (arg == QLatin1String("-verbose"))
         {


### PR DESCRIPTION
Two findings from driving eyepiece over thousands of tiles (the coastline test of OsmAnd-tools).

### A single `isIdle()` is not enough to call a frame complete

Right after a target change there is a window in which the requested state has been applied but the
resource requests for the new location are not registered yet, so `isIdle()` is true while the
framebuffer still holds nothing but the background and the grid. Rendering a list of scattered
tiles hits that window often enough to write blank images — and a blank tile is not obviously
broken, it is just a tile with no map on it, which in a water mask comparison reads as a perfect
failure ("0% water rendered against 98% in the reference").

Idle now has to hold over three polls, 10 ms apart, before the frame is read back.

Measured on the fixed cases of the coastline test, 54 tiles: **4 blank tiles before, 0 after**, and
the results then match the ones the same run produces with symbols enabled, case by case.

This is not specific to the tile mode - a single still or a frame of an animation can be read back
half loaded the same way - so the confirmation applies to every mode.

### `-noSymbols`

Renders without the map symbols provider, i.e. without labels and icons.

They cost far more than the geometry: **500 ms per tile with them against 30 ms without** (20
scattered z12 tiles, warm page cache, two maps, median of three rounds). A consumer that only looks
at the geometry - the coastline water mask test - can skip them and render at the speed of the
legacy renderer, which is what makes a 10 000 tile run possible at all.

The 276 fixed case tiles of that test come out **identical with and without symbols** once the idle
fix above is in: the same 31 failed tiles, the same worst percentages.

Tested on macOS (CGL): 276 tiles of the coastline cases, 20 scattered tiles at z12 in both modes,
and a 4x4 metatile against 16 separate tiles.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. The comparison with the legacy renderer seems slow.
2. You may switch the labels off for the ocean tiles.
3. Crashes have to be fixed too, and it is important to keep them in the report.

Decided by the agent, not requested explicitly:
- Measuring where the time of a tile goes before changing anything (start up 0.45 s, a repeated
  tile 3 ms, a cold tile 300-500 ms), which is what turned up the symbols cost.
- Finding, while checking whether disabling symbols changes the water masks, that the first
  measurement was wrong: `-noSymbols` looked 100x faster only because the renderer was reading back
  unfinished frames. That is the idle bug above, and it is the more important half of this PR.
- The shape of the fix (three confirmations 10 ms apart, in every mode rather than the tile mode
  only) and the `-noSymbols` name.
