### PR TITLE
Symbols: do not read past the ends of a path of less than two points

### DIFF
--- a/src/Map/MapObjectsSymbolsProvider_P.cpp
+++ b/src/Map/MapObjectsSymbolsProvider_P.cpp
@@ -926,6 +926,14 @@ bool OsmAnd::MapObjectsSymbolsProvider_P::СombinedPath::isAttachAllowed(
     const float maxGapBetweenPaths,
     float& outGapBetweenPaths) const
 {
+    // A path of less than two points has no direction, so nothing can be attached along it. Such a
+    // path does reach here - the points are taken from the map object as they are, and a degenerate
+    // way of a single point is not filtered anywhere - and the penultimate point below used to be
+    // read at index -1 for it, which is an out of range assert in a Qt with asserts and an out of
+    // bounds read in one without.
+    if (_points.size() < 2 || other->_points.size() < 2)
+        return false;
+
     const auto lastPoint = _points.back();
     const auto otherFirstPoint = other->_points.front();
     const auto gapVector = otherFirstPoint - lastPoint;


### PR DESCRIPTION
`СombinedPath::isAttachAllowed()` takes the penultimate point of one path and the second point of
the other:

```cpp
const auto penultimatePoint = _points[_points.size() - 2];
const auto otherSecondPoint = other->_points[1];
```

Nothing guarantees a path has two points. `_points` is copied from the map object as it comes
(`points31`, or the points of the visible area) and a degenerate way of a single point is not
filtered anywhere on the way here, so for such a path the first line indexes at **-1**: an
"index out of range" assert in a Qt built with asserts, an out of bounds read in one without.

A path of less than two points has no direction, so nothing can be attached along it -
`isAttachAllowed()` now answers false for it before touching any point.

### How it showed up

It aborted a run of the coastline rendering test of OsmAnd-tools after ~9000 tiles
([build 132](https://builder.osmand.net:8080/job/Web_Ocean_Tiles_Test/132/console)):

```
eyepiece died (exit code 134) on tile 16/17500/12563
ASSERT failure in QVector<T>::operator[]: "index out of range", ... qvector.h, line 453
```

```
frame #0: qt_assert_x
frame #2: OsmAnd::MapObjectsSymbolsProvider_P::СombinedPath::isAttachAllowed(...)
frame #3: OsmAnd::MapObjectsSymbolsProvider_P::combineOnPathSymbols(...)
frame #4: OsmAnd::MapObjectsSymbolsProvider_P::obtainData(...)
frame #7: OsmAnd::MapRendererResourcesManager::ResourceRequestTask::execute()
```

### Verification

Tile 16/17500/12563 (73.6N 83.9W, Nunavut) rendered with eyepiece over the downloaded maps, same
binary, same tile, only this patch differing:

| | crashes | tiles written |
|---|---|---|
| before | **5 of 10 runs** | 5 |
| after | **0 of 20 runs** | 20 |

It is a race in a worker thread, hence the 50% - the tile itself is deterministic. With
`-noSymbols` it never happened, which is what pointed at this provider in the first place.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. It failed again, look at the logs.
2. Crashes have to be fixed too, and it is important to keep them in the report.

Decided by the agent, not requested explicitly:
- Reproducing the assert locally from the tile in the Jenkins log and catching the stack with a
  breakpoint on `qt_assert_x` (the SIGABRT stack itself does not unwind), rather than reporting it.
- Fixing it by refusing the attach instead of filtering degenerate paths when they are collected -
  a path of one point is meaningless to attach to, and the guard also covers `_points.back()` on an
  empty path, which is undefined behaviour a point earlier.
