### PR TITLE
Let suspendRenderer() hand over an already suspended renderer

### DIFF
--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -445,8 +445,9 @@ public abstract class MapRendererView extends FrameLayout {
         synchronized (_mapRenderer) {
             stopRenderingView();
             if (isSuspended) {
+                // Renderer may be suspended in advance, for example when the activity is being
+                // recreated on a configuration change. Still hand it over to the new view.
                 Log.v(TAG, "Renderer was already suspended");
-                return null;
             } else {
                 Log.v(TAG, "Suspending renderer to reuse it in other view");
                 isSuspended = true;


### PR DESCRIPTION
Part 1 of 2 for the `onPause`/`onRelease` ANR (OsmAnd-Issues#3229). **This one must land first** —
osmandapp/OsmAnd#25866 depends on it and does nothing useful without it.

### Why

`setupRenderer(context, w, h, oldView)` already knows how to take a live renderer over from another
view: it calls `oldView.suspendRenderer()` and, on success, reuses the `IMapRenderer`, the `EGLThread`
and its EGL contexts instead of building everything again. That path is what Android Auto transitions
use.

It cannot be used on an activity configuration change, though. There the old view has to be suspended
*before* the old activity's view hierarchy is detached — otherwise `onDetachedFromWindow()` sees
`isSurfaceReady` and calls `releaseRendering()`, which is exactly the expensive main-thread wait we
want to avoid. And once the view has been suspended, `suspendRenderer()` returns `null` on the second
call, so the new view falls back to creating a whole new renderer.

### Change

`suspendRenderer()` now returns the renderer when the view is already suspended instead of `null`.
The suspend bookkeeping still runs only once; the second call just hands the renderer over.

The only caller is `setupRenderer()`, and it already handles the returned renderer being the same one
the view holds.

### Measured

Emulator, Android 15 arm64, software GPU, OsmAnd on Bremen at z16, 16 rotations with a map swipe
before each. Counted from the `MapRendererView` log, with the app-side change applied:

| per rotation | before | after |
|---|---|---|
| `Release rendering...` | 16 | 0 |
| `Setting up new renderer to initialize` | 16 | 0 |
| `Setting up provided renderer to reinitialize` | 0 | 16 |

Main-thread blocking, same run:

| ms | before (avg / max) | after (avg / max) |
|---|---|---|
| `performPause` | 172 / 353 | 50 / 95 |
| `performDestroy` | 134 / 272 | 18 / 57 |

The map renders identically after 16 rotations — no lost symbols, no black frame, no native crash,
same process.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Analyse the top Play Console crashes and ANRs, group them, and open a separate PR per group against
   the `r5.4` branch only.
2. Blind fixes are not acceptable — reproduce the ANR first, with a real ANR and a matching stack dump.
3. Post the analysis and the reproduction method as a comment on the internal issue, move it to the
   `5.4-map` milestone, then make the fix, verify it works, and push a draft PR if it fixes the problem.

Decided by the agent, not requested explicitly:
- Choice of fix. The reproduction showed the main thread blocking on the GL thread; reusing the
  existing suspend/hand-over path was picked over bounding the waits, because the EGL thread holds its
  monitor for the whole operation, so a `wait()` timeout cannot actually return early there.
- Splitting the work into this core change plus a separate app-side change, and marking both as drafts
  because they have to be merged in order.
- The verification method: an A/B on a rotation loop with the fix behind a system property so both arms
  come from one build, plus a patched-AAR build (only `MapRendererView` recompiled and spliced into the
  released 5.4 AAR) so the SWIG bindings and the prebuilt `.so` stayed untouched.
- Honest scope note below.

### What this does not fix

An ANR caused by one single stalled frame — the `GL_GenTextures` stall inside `libGLESv2_samsung.so`
seen in the Play traces — is not addressed. `handleOnPause()` still waits for the frame in flight. With
an artificial 3000 ms per-frame stall the pause blocked 3083 ms before and 3048 ms after. What this
change removes is the *rest* of the per-rotation main-thread cost, and the release/re-initialize churn
that makes the following frames heavy.
