### PR TITLE
Do not let a frame request reach a rendering view that is not started

### DIFF
--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -2366,8 +2366,17 @@ public abstract class MapRendererView extends FrameLayout {
             extends MapRendererSetupOptions.IFrameUpdateRequestCallback {
         @Override
         public void method(IMapRenderer mapRenderer) {
-            if (!isSuspended && _renderingView != null) {
-                _renderingView.requestRender();
+            // Renderer may request a frame before the rendering view is started, for example while
+            // the renderer is being handed over to a view of a paused activity: in that case
+            // setupRenderer() creates the rendering view, but leaves it without a renderer until
+            // handleOnResume(). Nothing may be thrown into the native caller either: an exception
+            // thrown out of a director method terminates the process.
+            try {
+                if (isViewStarted && !isSuspended && _renderingView != null) {
+                    _renderingView.requestRender();
+                }
+            } catch (Throwable e) {
+                Log.e(TAG, "Failed to request a frame", e);
             }
         }
     }
@@ -2380,6 +2389,12 @@ public abstract class MapRendererView extends FrameLayout {
             extends MapRendererSetupOptions.IGpuWorkerThreadPrologue {
         @Override
         public void method(IMapRenderer mapRenderer) {
+            EGLThread eglThread = MapRendererView.this.eglThread;
+            if (eglThread == null) {
+                Log.e(TAG, "EGL thread is missing");
+                return;
+            }
+
             if (eglThread.display == null) {
                 Log.e(TAG, "EGL display is missing");
                 return;


### PR DESCRIPTION
Fixes the Play crash `70daec1e` (~96 affected users, 5.4.x, foreground): the process aborts with

```
terminating due to uncaught exception of type Swig::DirectorException: Attempt to invoke virtual
method 'void android.opengl.GLSurfaceView$GLThread.requestRender()' on a null object reference

#06 SwigDirector_MapRendererSetupOptions_IFrameUpdateRequestCallback::operator()
#07 OsmAnd::MapRenderer::notifyRequestedStateWasUpdated
#10 OsmAnd::MapRenderer::setAzimuth
#14 net.osmand.plus.views.MapViewWithLayers.setupAtlasMapRendererView
#20 net.osmand.plus.auto.NavigationSession.onStop
```

## What happens

When the Android Auto session stops, `NavigationSession.onStop()` hands the live renderer of the
offscreen car view back to the map view of the phone activity and changes its state one line later
(`setAzimuth(0)`).

If the phone activity is paused at that moment, `setupRenderer()` takes the `initOnResume` path: it
creates the `RenderingView` but leaves `setRenderer()` for `handleOnResume()`, so
`GLSurfaceView.mGLThread` is still null. The renderer, however, is already live and bound to the new
view's `IFrameUpdateRequestCallback`, so the state change goes straight into

```java
public void method(IMapRenderer mapRenderer) {
    if (!isSuspended && _renderingView != null) {
        _renderingView.requestRender();   // mGLThread == null -> NPE
    }
}
```

The public `requestRender()` guards this with `isViewStarted`; this director callback does not. An
exception thrown out of a SWIG director method reaches native code, where `__cxa_throw` finds no
handler and `std::terminate` aborts the process.

## Fix

- The frame-update callback gets the `isViewStarted` check the public `requestRender()` already has,
  and catches `Throwable`, so nothing can escape into the native caller:

```java
try {
    if (isViewStarted && !isSuspended && _renderingView != null) {
        _renderingView.requestRender();
    }
} catch (Throwable e) {
    Log.e(TAG, "Failed to request a frame", e);
}
```

- The GPU-worker prologue reads `eglThread` once and returns if it is null: `stopRenderer()` nulls it,
  and a NPE there aborts the process in the same way.

Dropping a frame request while the view is not started loses nothing: the view cannot draw until it is
started, and `handleOnResume()` starts it and draws.

## Verified

Instrumented test `RendererHandoverToPausedViewTest` (osmandapp/OsmAnd#25867), emulator with
Android 15 arm64, `nightlyFreeOpenglArm64Debug`:

| | before | after |
|---|---|---|
| test result | `Process crashed.` | `OK (1 test)` |
| abort message | `Swig::DirectorException ... requestRender() on a null object reference` | none |
| director frame | `SwigDirector_...IFrameUpdateRequestCallback::operator()` | none |

The reproduction stack matches the Play trace frame for frame from `abort_message` through
`__cxa_throw`, the director callback, `notifyRequestedStateWasUpdated` and `setAzimuth` down to
`Java_net_osmand_core_jni_OsmAndCoreJNI_IMapRenderer_1setAzimuth`. The map still renders and follows
gestures on the patched build — checked again after two rotations and a pan, with no
"Failed to request a frame" logged, so the added check never rejects a legitimate request.

Internal task: osmandapp/OsmAnd-Issues#3314

## Merge order

This PR first. The Android PR only adds the regression test, and that test kills the process until
this change is in the 5.4 `OsmAndCore_android` snapshot.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Clean up the working state of the previous crash round and report what crash groups are left and
   what can be fixed.
2. D, H and G are the same memory problem — do not patch them, leave a short comment in the epic that
   they need a systemic approach; study and fix B instead.
3. B has to be reproduced as well.
4. If there is no internal issue for it, create one for 5.4-map in code review with the test and the
   description, and set the parent epic.

Decided by the agent, not requested explicitly:
- Reading the real Play trace of `70daec1e` before writing any code, instead of relying on the earlier
  summary of it.
- Reproducing through a direct hand-over to a paused view rather than through a head unit: the field
  path (`NavigationSession.onStop`) needs a car session, while the state that crashes — a live renderer
  bound to a view whose rendering view is not started — is reachable with the same public API.
- Guarding the GPU-worker prologue against a null `eglThread`, which is the same defect class but a
  different callback and is not covered by the crash above.

