### PR TITLE
Let the GPU worker be interrupted between upload slices

### DIFF
--- a/include/OsmAndCore/Map/MapRendererSetupOptions.h
+++ b/include/OsmAndCore/Map/MapRendererSetupOptions.h
@@ -99,6 +99,21 @@ namespace OsmAnd
         }
 #endif // !defined(SWIG)
 
+        // Maximal number of resources the GPU worker uploads before it re-checks whether it has
+        // been asked to stop. 0 means "drain the queue in one go", which is cheapest - each slice
+        // costs a full walk of every resource collection - but leaves anyone waiting on the worker
+        // waiting for the whole queue. Set it only where a frame must be able to interrupt uploads.
+        unsigned int gpuWorkerUploadSliceSize;
+#if !defined(SWIG)
+        inline MapRendererSetupOptions& setGpuWorkerUploadSliceSize(
+            const unsigned int newGpuWorkerUploadSliceSize)
+        {
+            gpuWorkerUploadSliceSize = newGpuWorkerUploadSliceSize;
+
+            return *this;
+        }
+#endif // !defined(SWIG)
+
         QString pathToOpenGLShadersCache;
 #if !defined(SWIG)
         inline MapRendererSetupOptions& setPathToOpenGLShadersCache(

--- a/src/Map/MapRenderer.cpp
+++ b/src/Map/MapRenderer.cpp
@@ -54,6 +54,7 @@ OsmAnd::MapRenderer::MapRenderer(
     , _gpuWorkerThreadId(nullptr)
     , _gpuWorkerThreadIsAlive(false)
     , _gpuWorkerIsSuspended(0)
+    , _gpuWorkerYieldRequested(0)
     , _renderThreadId(nullptr)
     , _currentDebugSettings(baseDebugSettings_->createCopy())
     , _currentDebugSettingsAsConst(_currentDebugSettings)
@@ -289,14 +290,32 @@ void OsmAnd::MapRenderer::processGpuWorker()
         unsigned int resourcesUploadedCount = 0u;
         unsigned int resourcesUnloadedCount = 0u;
 
-        // In every layer we have, upload pending resources to GPU without limiting
+        // Upload pending resources to GPU. Draining the whole queue in one call keeps
+        // _gpuWorkerThreadActiveMutex held for as long as that takes, and a frame that wants to
+        // suspend the worker before encoding then waits for all of it. Slicing lets the worker be
+        // stopped between resources - but every slice costs a full walk of all resource
+        // collections, so it stays off (0) unless the platform asked for it.
+        const auto uploadsPerSlice = _setupOptions.gpuWorkerUploadSliceSize;
         int unprocessedRequests = 0;
         do
         {
             const auto requestsToProcess = _resourcesGpuSyncRequestsCounter.fetchAndAddOrdered(0);
             unsigned int resourcesUploaded = 0u;
             unsigned int resourcesUnloaded = 0u;
-            _resources->syncResourcesInGPU(0, nullptr, &resourcesUploaded, &resourcesUnloaded);
+            bool moreThanSliceAvailable = false;
+            do
+            {
+                unsigned int slicedUploaded = 0u;
+                unsigned int slicedUnloaded = 0u;
+                moreThanSliceAvailable = false;
+                _resources->syncResourcesInGPU(
+                    uploadsPerSlice, &moreThanSliceAvailable, &slicedUploaded, &slicedUnloaded);
+                resourcesUploaded += slicedUploaded;
+                resourcesUnloaded += slicedUnloaded;
+            } while (uploadsPerSlice > 0
+                && moreThanSliceAvailable
+                && _gpuWorkerThreadIsAlive
+                && _gpuWorkerYieldRequested.loadAcquire() < 1);
             if (resourcesUploaded > 0 || resourcesUnloaded > 0)
             {
                 invalidateFrame();
@@ -305,7 +324,9 @@ void OsmAnd::MapRenderer::processGpuWorker()
             }
             unprocessedRequests = _resourcesGpuSyncRequestsCounter.fetchAndAddOrdered(-requestsToProcess) - requestsToProcess;
             
-        } while (_gpuWorkerThreadIsAlive && unprocessedRequests > 0);
+        } while (_gpuWorkerThreadIsAlive
+            && unprocessedRequests > 0
+            && _gpuWorkerYieldRequested.loadAcquire() < 1);
 
         if (OsmAnd::isPerformanceMetricsEnabled())
             OsmAnd::getPerformanceMetrics().syncFinish(resourcesUploadedCount, resourcesUnloadedCount);
@@ -957,7 +978,15 @@ QString OsmAnd::MapRenderer::getNotIdleReason() const
 
 bool OsmAnd::MapRenderer::suspendGpuWorker()
 {
+    // Ask first, wait second: the worker checks this between upload slices, so by the time the
+    // mutex below is free it has stopped at a slice boundary rather than after the whole queue.
+    _gpuWorkerYieldRequested.storeRelease(1);
+
     QMutexLocker scopedLocker(&_gpuWorkerThreadActiveMutex);
+
+    // The worker is now parked and cannot restart while this mutex is held, so the request has
+    // served its purpose - leaving it set would stop the worker slicing once it resumes.
+    _gpuWorkerYieldRequested.storeRelease(0);
 
     if (_gpuWorkerIsSuspended.loadAcquire() > 0)
         return false;

--- a/src/Map/MapRenderer.h
+++ b/src/Map/MapRenderer.h
@@ -146,6 +146,10 @@ namespace OsmAnd
         QMutex _gpuWorkerThreadWakeupMutex;
         QWaitCondition _gpuWorkerThreadWakeup;
         QAtomicInt _gpuWorkerIsSuspended;
+        // Asks the worker to stop between upload slices. It holds _gpuWorkerThreadActiveMutex for
+        // the whole of processGpuWorker(), so without this anyone waiting on that mutex waits for
+        // however many resources happened to be queued - which is what a frame cannot afford.
+        QAtomicInt _gpuWorkerYieldRequested;
         mutable QMutex _gpuWorkerThreadActiveMutex;
         void gpuWorkerThreadProcedure();
         void processGpuWorker();

--- a/src/Map/MapRendererSetupOptions.cpp
+++ b/src/Map/MapRendererSetupOptions.cpp
@@ -6,6 +6,7 @@ OsmAnd::MapRendererSetupOptions::MapRendererSetupOptions()
     , gpuWorkerThreadEpilogue(nullptr)
     , frameUpdateRequestCallback(nullptr)
     , maxNumberOfRasterMapLayersInBatch(0)
+    , gpuWorkerUploadSliceSize(0)
     , displayDensityFactor(1.0f)
     , elevationVisualizationEnabled(true)
 {

--- a/src/Map/OpenGL/OpenGLES2plus/GPUAPI_OpenGLES2plus.cpp
+++ b/src/Map/OpenGL/OpenGLES2plus/GPUAPI_OpenGLES2plus.cpp
@@ -199,6 +199,10 @@ bool OsmAnd::GPUAPI_OpenGLES2plus::initialize()
     glVersionRegExp.indexIn(QString(QLatin1String(reinterpret_cast<const char*>(glVersionString))));
     _glVersion = glVersionRegExp.cap(1).toUInt() * 10 + glVersionRegExp.cap(2).toUInt();
     LogPrintf(LogSeverityLevel::Info, "OpenGLES version %d [%s]", glVersion, glVersionString);
+    LogPrintf(LogSeverityLevel::Info, "OpenGLES vendor [%s]", glGetString(GL_VENDOR));
+    GL_CHECK_RESULT;
+    LogPrintf(LogSeverityLevel::Info, "OpenGLES renderer [%s]", glGetString(GL_RENDERER));
+    GL_CHECK_RESULT;
     if (glVersion < 30)
     {
         LogPrintf(LogSeverityLevel::Info, "This OpenGLES version is not supported");


### PR DESCRIPTION
Groundwork for running the iOS Simulator through ANGLE (see osmandapp/OsmAnd-iOS#5734). No behaviour change on any current platform.

## The problem

`processGpuWorker()` drains the whole pending queue inside a single `syncResourcesInGPU(0, ...)` call while holding `_gpuWorkerThreadActiveMutex`. Nothing waited on that mutex before, so its duration never mattered — but a renderer that must stop uploads before encoding a frame then waits for however many resources happen to be queued. Measured on a zoom-out burst: 25 to 34 resources per batch, which is a visible stall every frame.

## The change

Upload in bounded slices, re-checking `_gpuWorkerYieldRequested` between them, and have `suspendGpuWorker()` set that flag *before* taking the mutex, so its wait is bounded by one slice instead of by the queue.

The slice size comes from `MapRendererSetupOptions::gpuWorkerUploadSliceSize` and **defaults to 0, which reproduces the previous single-call behaviour exactly**. Each slice costs a full walk of every resource collection (`unloadResources()` plus `uploadResources()`), so only a platform that actually needs to interrupt the worker pays for it. Android and iOS-on-device are byte-for-byte unchanged.

## Why it is needed

On the iOS Simulator, ANGLE translates GLES to Metal. Metal organises rendering into render passes, and ending an encoder part-way through a frame discards what was drawn unless it is explicitly reloaded — so GPU-worker uploads running concurrently with frame encoding leave the map blank until the app restarts. Suspending the worker around the frame fixes it; slicing is what makes that affordable.

## Also

`GL_VENDOR` and `GL_RENDERER` are now logged next to the existing `GL_VERSION` line. Which implementation is actually in use is not otherwise visible from the logs, and it is exactly what identifies cases like the Simulator serving GLES through a software rasteriser.

## Verified

- iPhone SE (3rd gen), iOS 26.4 — `Apple A15 GPU`, renders normally
- Simulator through ANGLE — map no longer disappears, no stutter
- Device and Simulator builds both checked