### PR TITLE
Keep renderer "my location" position in sync while the marker is animated

### DIFF
--- a/src/Map/MapMarkersAnimator_P.cpp
+++ b/src/Map/MapMarkersAnimator_P.cpp
@@ -522,7 +522,11 @@ void OsmAnd::MapMarkersAnimator_P::positionSetter(const Key key, const PointI64 
     {
         const auto location31 = Utilities::normalizeCoordinates(newValue, ZoomLevel31);
         marker->setPosition(location31);
-        if (marker->isAccuracyCircleSupported && marker->isAccuracyCircleVisible())
+        // Renderer draws the accuracy circle and the view-angle sector at its own "my location"
+        // position, so it has to follow the marker for the whole animation. It must not depend on
+        // the circle being visible: the sector is drawn from the same position and stays visible
+        // when the accuracy circle is switched off.
+        if (marker->isAccuracyCircleSupported)
             _renderer->setMyLocation31(location31);
     }
 }


### PR DESCRIPTION
Internal issue: osmandapp/OsmAnd-Issues#3325

### Problem

The location icon is a `MapMarker`, while the accuracy circle and the view angle sector are drawn by
the renderer at `MapRendererState::myLocation31`. When my location is animated and the accuracy
circle is hidden (profile appearance → Location radius = Off), that state stopped being updated, so
the view angle sector was left at the position of the last non-animated update while the location
icon kept moving. The gap grows with the distance travelled — on a real drive the sector ended up
about 20 km away from the arrow.

Measured on an emulator (OpenGL renderer, simulated positions, map panned away from my location):
the sector stayed at the same pixel while the arrow moved 591 → 779 → 958 px, i.e. the gap grew
66 → 253 → 431 px over 15 seconds and kept growing.

### Fix

`MapMarkersAnimator_P::positionSetter()` now pushes the position for every animation step of a
marker that supports the accuracy circle, without also requiring the circle to be visible. The
sector is drawn from the same position and stays visible when the circle is switched off, so the
position must follow the marker in both cases.

Only "my location" markers are built with `setIsAccuracyCircleSupported(true)`
(`PointLocationLayer` on Android, `OAMyPositionLayer` on iOS); the default is `false`, so no other
marker can reach `setMyLocation31()`.

Fixes the issue for both Android and iOS. The Android side additionally keeps the state in sync on
every frame — see osmandapp/OsmAnd#25897, which also contains the regression test.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Help me reproduce the bug where the location and the view angle get separated (screenshot from a
   real drive).
2. Create a pull request for 5.5 and a test that catches regressions or similar bugs; also create a
   bug on the 5.5-map milestone.

Decided by the agent, not requested explicitly:
- Reproducing with the development plugin's position simulation instead of `adb emu geo fix`
  (emulator fixes carry no timestamp, so the location animation never starts and the bug is hidden).
- Fixing the root cause in core rather than only in the app layer, so that iOS is covered as well.