### PR TITLE
[5.4] Support deferred renderer handoff during screen rotation

### DIFF
--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -271,7 +271,7 @@ public abstract class MapRendererView extends FrameLayout {
             isReinitializing = (isSuspended && _mapRenderer != null && _mapRenderer.isRenderingInitialized());
             if (!isReinitializing) {
                 Log.v(TAG, "Setting up new renderer to initialize...");
-                eglThread = new EGLThread("OpenGLThread");
+                eglThread = new EGLThread("OpenGLThread", this);
                 eglThread.start();
                 _mapRenderer = createMapRendererInstance();
                 isInitializing = true;
@@ -303,6 +303,7 @@ public abstract class MapRendererView extends FrameLayout {
 
             // Take all EGL references from old map renderer view
             eglThread = oldView.eglThread;
+            eglThread.rendererView = this;
 
             // Reset rendering options for current view
             if (eglThread.gpuWorkerContext != null && eglThread.gpuWorkerFakeSurface != null) {
@@ -438,15 +439,36 @@ public abstract class MapRendererView extends FrameLayout {
     public synchronized IMapRenderer suspendRenderer() {
         Log.v(TAG, "suspendRenderer()");
 
-        if (_mapRenderer == null || !_mapRenderer.isRenderingInitialized() || _exportableMapRenderer == null) {
+        if (!prepareRendererForReuse()) {
             return null;
+        }
+
+        // A prepared renderer may be handed over only once. The receiving view publishes
+        // its own exportable reference after it has initialized its rendering surface.
+        IMapRenderer renderer = _exportableMapRenderer;
+        _exportableMapRenderer = null;
+        return renderer;
+    }
+
+    /**
+     * Stops this view while retaining its initialized renderer and EGL contexts for a later
+     * {@link #setupRenderer(Context, int, int, MapRendererView)} handoff. Call before the old
+     * view is detached. If no handoff follows, the owner must call {@link #stopRenderer()}.
+     *
+     * @return whether a renderer is available for handoff
+     */
+    public synchronized boolean prepareRendererForReuse() {
+        Log.v(TAG, "prepareRendererForReuse()");
+
+        if (_mapRenderer == null || !_mapRenderer.isRenderingInitialized() || _exportableMapRenderer == null) {
+            return false;
         }
 
         synchronized (_mapRenderer) {
             stopRenderingView();
             if (isSuspended) {
                 Log.v(TAG, "Renderer was already suspended");
-                return null;
+                return true;
             } else {
                 Log.v(TAG, "Suspending renderer to reuse it in other view");
                 isSuspended = true;
@@ -460,7 +482,7 @@ public abstract class MapRendererView extends FrameLayout {
             _mapAnimator = null;
             _mapMarkersAnimator = null;
         }
-        return _exportableMapRenderer.isRenderingInitialized() ? _exportableMapRenderer : null;
+        return _exportableMapRenderer.isRenderingInitialized();
     }
 
     public synchronized void stopRenderer() {
@@ -2483,7 +2505,10 @@ public abstract class MapRendererView extends FrameLayout {
         }
     }
 
-    private class EGLThread extends Thread {
+    private static class EGLThread extends Thread {
+
+        // The thread outlives a view during handoff; never retain an implicit original view.
+        protected volatile MapRendererView rendererView;
 
         private EGL10 egl;
         private EGLDisplay display;
@@ -2533,8 +2558,9 @@ public abstract class MapRendererView extends FrameLayout {
         public volatile boolean ok;
         public volatile long preFlushTime = SystemClock.uptimeMillis();
 
-        public EGLThread(String name) {
+        public EGLThread(String name, MapRendererView rendererView) {
             super(name);
+            this.rendererView = rendererView;
         }
 
         // NOTE: It needs to be called from synchronized block
@@ -2696,13 +2722,13 @@ public abstract class MapRendererView extends FrameLayout {
                         case RENDER_FRAME:
                         mapRenderer.update();
                         boolean isReady = mapRenderer.prepareFrame();
-                        _isRenderingActive = isReady ? mapRenderer.renderFrame() : false;
+                        rendererView._isRenderingActive = isReady ? mapRenderer.renderFrame() : false;
                         preFlushTime = SystemClock.uptimeMillis();
                         if (isReady) {
                             gl.glFlush();
                             if (byteBuffer != null) {
                                 gl.glFinish();
-                                if (_frameReadingMode) {
+                                if (rendererView._frameReadingMode) {
                                     egl.eglSwapBuffers(display, surface);
                                 }
                                 synchronized (byteBuffer) {
@@ -2718,10 +2744,10 @@ public abstract class MapRendererView extends FrameLayout {
                         break;
 
                         case RELEASE_RENDERING:
-                        _mapAnimationFinished = true;
-                        _mapMarkersAnimationFinished = true;
+                        rendererView._mapAnimationFinished = true;
+                        rendererView._mapMarkersAnimationFinished = true;
                         mapRenderer.releaseRendering(true);
-                        _isRenderingActive = false;
+                        rendererView._isRenderingActive = false;
                         break;
 
                         case DESTROY_SURFACE:

--- a/wrappers/android/tests/test_renderer_reuse.py
+++ b/wrappers/android/tests/test_renderer_reuse.py
@@ -1,0 +1,220 @@
+"""Test the actual renderer handoff and EGL thread ownership methods in isolation.
+
+Run with Python 3 and JDK 17+ on PATH, or set JAVA_HOME. An optional first
+argument selects a different repository checkout (for regression controls).
+Platform/native dependencies use minimal doubles; this does not compile the app
+or validate Android lifecycle ordering, real EGL drivers, or rendering output.
+"""
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[3]
+
+
+def block(source, signature):
+    start = source.index(signature)
+    opening = source.index('{', start)
+    depth = 1
+    end = opening + 1
+    while depth:
+        depth += (source[end] == '{') - (source[end] == '}')
+        end += 1
+    return source[start:end]
+
+
+
+core = (ROOT / 'wrappers/android/src/net/osmand/core/android/MapRendererView.java').read_text()
+
+core_methods = '\n'.join(block(core, signature) for signature in [
+    'public synchronized void setupRenderer(',
+    'public synchronized IMapRenderer suspendRenderer()',
+    'public synchronized boolean prepareRendererForReuse()',
+    'public synchronized void stopRenderer()',
+    'private void releaseRendering()',
+    'public void stopRenderingView()',
+    'public final void handleOnPause()',
+    'private static class EGLThread extends Thread',
+])
+core_test = r'''
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+class MapRendererView {
+    static String TAG = "test";
+    static class Log {
+        static void v(String a, String b) {}
+        static void w(String a, String b) {}
+        static void e(String a, String b) {}
+        static void e(String a, String b, Exception e) {}
+    }
+    static class NativeCore { static void checkIfLoaded() {} }
+    static class Context {}
+    static class Metrics { float density = 1; }
+    static class Resources { Metrics getDisplayMetrics() { return new Metrics(); } }
+    Resources getResources() { return new Resources(); }
+    static class IMapRenderer {
+        boolean initialized = true;
+        boolean isRenderingInitialized() { return initialized; }
+        boolean initializeRendering(boolean flag) { initialized = true; return true; }
+        void releaseRendering(boolean flag) { initialized = false; }
+        void setup(Options o) {}
+        void update() {}
+        boolean prepareFrame() { return true; }
+        boolean renderFrame() { return true; }
+    }
+    static class Options {
+        void setDisplayDensityFactor(float v) {}
+        void setGpuWorkerThreadEnabled(boolean v) {}
+        void setGpuWorkerThreadPrologue(Object v) {}
+        void setGpuWorkerThreadEpilogue(Object v) {}
+        void setFrameUpdateRequestCallback(Object v) {}
+    }
+    static class Callback { Object getBinding() { return this; } }
+    static class MapAnimator {
+        MapAnimator(boolean flag) {}
+        void setMapRenderer(IMapRenderer r) {}
+    }
+    static class MapMarkersAnimator { void setMapRenderer(IMapRenderer r) {} }
+    static class RenderingView { int pauses; void onPause() { pauses++; } }
+    static class EGLDisplay {}
+    static class EGLConfig {}
+    static class EGLSurface {}
+    static class EGLContext {
+        static Object getEGL() { return new EGL10(); }
+        Object getGL() { return new GL10(); }
+    }
+    static class GL10 {
+        static int GL_RGBA = 1, GL_UNSIGNED_BYTE = 2;
+        void glFlush() {}
+        void glFinish() {}
+        void glReadPixels(int x, int y, int w, int h, int f, int t, ByteBuffer b) {}
+    }
+    static class EGL10 {
+        static int EGL_DEFAULT_DISPLAY=0, EGL_WIDTH=1, EGL_HEIGHT=2, EGL_NONE=3;
+        static EGLDisplay EGL_NO_DISPLAY;
+        static EGLContext EGL_NO_CONTEXT;
+        static EGLSurface EGL_NO_SURFACE;
+        int swaps;
+        EGLDisplay eglGetDisplay(int d) { return new EGLDisplay(); }
+        boolean eglInitialize(EGLDisplay d, int[] v) { return true; }
+        EGLContext eglCreateContext(EGLDisplay d, EGLConfig c, EGLContext x, int[] a) { return new EGLContext(); }
+        EGLSurface eglCreatePbufferSurface(EGLDisplay d, EGLConfig c, int[] a) { return new EGLSurface(); }
+        EGLSurface eglCreateWindowSurface(EGLDisplay d, EGLConfig c, Object w, Object a) { return new EGLSurface(); }
+        boolean eglMakeCurrent(EGLDisplay d, EGLSurface a, EGLSurface b, EGLContext c) { return true; }
+        void eglDestroyContext(EGLDisplay d, EGLContext c) {}
+        void eglDestroySurface(EGLDisplay d, EGLSurface s) {}
+        void eglSwapBuffers(EGLDisplay d, EGLSurface s) { swaps++; }
+        void eglTerminate(EGLDisplay d) {}
+        int eglGetError() { return 0; }
+    }
+    static class ComponentSizeChooser {
+        EGLConfig makeConfig(EGL10 egl, EGLDisplay display) { return new EGLConfig(); }
+    }
+    static class SystemClock { static long uptimeMillis() { return System.currentTimeMillis(); } }
+    static String getEglErrorString(int error) { return "test"; }
+    enum EGLThreadOperation { NO_OPERATION, CHOOSE_CONFIG, CREATE_CONTEXTS, CREATE_WINDOW_SURFACE,
+        CREATE_PIXELBUFFER_SURFACE, INITIALIZE_RENDERING, RENDER_FRAME, RELEASE_RENDERING,
+        DESTROY_SURFACE, DESTROY_CONTEXTS }
+    IMapRenderer _mapRenderer, _exportableMapRenderer;
+    EGLThread eglThread;
+    MapAnimator _mapAnimator;
+    MapMarkersAnimator _mapMarkersAnimator;
+    Options setupOptions = new Options();
+    Callback _gpuWorkerThreadPrologue = new Callback(), _gpuWorkerThreadEpilogue = new Callback(),
+        _renderRequestCallback = new Callback();
+    int _windowWidth, _windowHeight, removals, maxFrameRate;
+    boolean _inWindow, isSuspended, isInitializing, isReinitializing, isPaused, initOnResume,
+        isViewStarted = true, _frameReadingMode, _isRenderingActive,
+        _mapAnimationFinished, _mapMarkersAnimationFinished;
+    ByteBuffer _byteBuffer;
+    List<Object> listeners = new ArrayList<>();
+    RenderingView _renderingView = new RenderingView();
+    void removeRenderingView() { removals++; _renderingView = null; }
+    void startRenderingView(Context context) { isViewStarted = true; }
+    void setMaximumFrameRate(int rate) { maxFrameRate = rate; }
+    int getMaximumFrameRate() { return maxFrameRate; }
+    IMapRenderer createMapRendererInstance() { return new IMapRenderer(); }
+
+    __METHODS__
+
+    static int checks;
+    static void check(boolean ok, String name) {
+        checks++;
+        if (!ok) throw new AssertionError(name);
+    }
+    static MapRendererView ready() {
+        MapRendererView view = new MapRendererView();
+        view._mapRenderer = view._exportableMapRenderer = new IMapRenderer();
+        view.eglThread = new EGLThread("isolated-test", view);
+        view.eglThread.gl = new GL10();
+        view.eglThread.setDaemon(true);
+        view.maxFrameRate = 20;
+        return view;
+    }
+    public static void main(String[] args) throws Exception {
+        MapRendererView empty = new MapRendererView();
+        check(!empty.prepareRendererForReuse() && empty.suspendRenderer() == null, "absent renderer");
+        MapRendererView notReady = ready();
+        notReady._mapRenderer.initialized = false;
+        check(!notReady.prepareRendererForReuse(), "uninitialized renderer");
+        MapRendererView unpublished = ready();
+        unpublished._exportableMapRenderer = null;
+        check(!unpublished.prepareRendererForReuse(), "unpublished renderer");
+
+        MapRendererView direct = ready();
+        IMapRenderer immediate = direct.suspendRenderer();
+        check(immediate == direct._mapRenderer, "immediate Android Auto handoff");
+        check(direct.suspendRenderer() == null && !direct.prepareRendererForReuse(), "no duplicate direct export");
+
+        MapRendererView old = ready();
+        old.handleOnPause();
+        check(!old.isSuspended && old._exportableMapRenderer != null && old.removals == 0, "background pause stays a pause");
+        IMapRenderer renderer = old._mapRenderer;
+        EGLThread thread = old.eglThread;
+        check(old.prepareRendererForReuse(), "prepare before activity destruction");
+        check(old.prepareRendererForReuse() && old.removals == 1, "idempotent prepare");
+        check(renderer.initialized && old._exportableMapRenderer == renderer, "keep native resources available");
+        check(old.listeners.isEmpty() && old._mapAnimator == null && old._mapMarkersAnimator == null, "detach old listeners/animators");
+        MapRendererView next = new MapRendererView();
+        next.setupRenderer(new Context(), 0, 0, old);
+        check(next._mapRenderer == renderer && next.eglThread == thread, "reuse native renderer and thread");
+        check(next.maxFrameRate == 20 && next.isReinitializing, "retain frame rate and rebind surface");
+        check(old.suspendRenderer() == null && !old.prepareRendererForReuse(), "prepared export consumed once");
+        check(thread.rendererView == next, "thread follows new view");
+        for (java.lang.reflect.Field field : EGLThread.class.getDeclaredFields()) {
+            check(!field.getName().startsWith("this$"), "no implicit original Activity reference");
+        }
+
+        thread.mapRenderer = renderer;
+        thread.byteBuffer = ByteBuffer.allocateDirect(4);
+        next._frameReadingMode = true;
+        thread.start();
+        synchronized (thread) { thread.startAndCompleteOperation(EGLThreadOperation.RENDER_FRAME); }
+        check(next._isRenderingActive && !old._isRenderingActive, "frame state belongs to receiving view");
+        check(thread.egl.swaps == 1, "frame reading mode belongs to receiving view");
+        next.stopRenderer();
+        check(next._mapAnimationFinished && next._mapMarkersAnimationFinished && !old._mapAnimationFinished,
+            "release state belongs to receiving view");
+        check(!renderer.initialized && thread.isStopped, "normal destruction still releases and stops");
+
+        MapRendererView abandoned = ready();
+        abandoned.eglThread.start();
+        check(abandoned.prepareRendererForReuse(), "prepare abandonment");
+        abandoned.stopRenderer();
+        check(!abandoned._mapRenderer.initialized && abandoned.suspendRenderer() == null, "abandoned handoff releases normally");
+        System.out.println("Core renderer handoff and thread ownership: " + checks + " assertions passed");
+    }
+}
+'''.replace('__METHODS__', core_methods)
+
+with tempfile.TemporaryDirectory(prefix='renderer-isolated-tests-') as temp:
+    work = Path(temp)
+    source_file = work / 'MapRendererView.java'
+    source_file.write_text(core_test)
+    java_bin = Path(os.environ['JAVA_HOME']) / 'bin' if 'JAVA_HOME' in os.environ else Path('')
+    subprocess.run([str(java_bin / 'javac'), '-d', temp, str(source_file)], check=True)
+    subprocess.run([str(java_bin / 'java'), '-cp', temp, 'MapRendererView'], check=True, timeout=15)


### PR DESCRIPTION
Screen rotation currently destroys the phone's initialized renderer and EGL contexts before the replacement Activity can reuse them. This adds a deferred handoff to the Android wrapper, for use by the [companion Android PR](https://github.com/osmandapp/OsmAnd/pull/25921), which limits retention to actual display rotation.

This is a separate proposal from #1104, as requested. The companion is also separate from osmandapp/Osmand#25866. Neither existing PR is modified or closed.

## Behavior and implementation

The existing Android Auto path calls `setupRenderer(..., oldView)`, which suspends the old view and takes its native renderer and EGL thread. Activity recreation needs two distinct steps: suspend before the old view hierarchy is detached, then transfer when the replacement view is created. Previously, the second `suspendRenderer()` call returned `null`, so the replacement could not take an already suspended renderer.

- Add `prepareRendererForReuse()`. It stops/removes the rendering view and clears its listeners and animators while retaining the initialized native renderer and EGL contexts. Repeated preparation is allowed until transfer. An absent, uninitialized, or already exported renderer returns `false`, allowing ordinary cleanup.
- Keep `suspendRenderer()` as the immediate transfer entry point used by `setupRenderer()`. It prepares if necessary, returns the renderer, and clears the old view's exportable reference. A stale view cannot export the renderer a second time after handoff.
- Make `EGLThread` static and give it an explicit current `rendererView`. `setupRenderer()` updates that reference when it takes the thread. Previously the inner thread implicitly retained the original view/Activity and accessed that view's rendering-active, frame-reading, and animation-completion fields after handoff. These accesses now target the receiving view.
- Preserve the existing renderer, EGL thread, frame-rate setting, and surface reinitialization path. The replacement view still creates its own surface and rebinds callbacks.

The core wrapper does not decide which lifecycle events permit retention. That policy belongs to the companion Android change. Ordinary `handleOnPause()`, resource release, and `stopRenderer()` continue to work. If a prepared renderer is abandoned, its owner must call `stopRenderer()`; the new method documents that contract. There are no C++ or JNI signature changes.

## Dependency and rollout

Merge this core change first, rebuild/publish the 5.4 Android wrapper artifacts, and then merge the companion Android change with those updated artifacts. The companion calls the new Java method, so both the AAR and the wrapper JAR used by the legacy flavor need to contain it. This PR does not publish artifacts or change dependency versions.

## Validation

Run from the core repository with Python 3 and JDK 17+ (`JAVA_HOME` can select the JDK):

```sh
python3 wrappers/android/tests/test_renderer_reuse.py
git diff --check
```

Both passed. The isolated test runs the actual Java bodies of setup, preparation, transfer, pause, release, stop, and the complete EGL thread, with minimal platform/native doubles: **44 assertions passed**. It covers immediate Android Auto-style transfer, preparation before a later transfer, duplicate-transfer rejection, missing/uninitialized renderers, background pause, normal destruction, abandonment cleanup, the current thread owner, frame-reading mode, and animation state after transfer. It also checks that the thread has no implicit outer-view field.

Negative controls were run against temporary source copies: removing export consumption fails the duplicate-transfer assertion; removing the thread-owner update fails the receiving-view assertion.

These checks do not compile the complete Android wrapper/app or exercise real EGL drivers, native resource uploads, or actual Activity lifecycle ordering. The companion `r5.4` repository's `AGENTS.md` prohibits Gradle builds and reconstructed Android compilation, so full APK/emulator validation was not performed in this task. This remains a draft for integration verification; no new timing or ANR-reduction measurements are claimed.

Before making the pair ready, verify repeated portrait/landscape rotations, Android Auto connect/disconnect in both directions, ordinary background/resume, screen lock/unlock, and final destruction using matching 5.4 wrapper artifacts. Confirm the same renderer/thread is reused on rotation, frames continue on the new view, and normal destruction releases resources.

## AI disclaimer

Produced with Codex (GPT-6).

Prompts used (summarised):
1. Assess reusing the Android Auto renderer-suspension mechanism for Android device screen orientation changes, excluding other events such as backgrounding.
2. Create the needed branches and pull requests against the core and Android 5.4 branches, with a complete explanation.
3. After the existing PRs were identified, explicitly choose a separate rotation-only pair and continue the work.

Decided by the agent, not requested explicitly: use separate preparation and single-use transfer operations; transfer the EGL thread's explicit view reference to avoid retaining/updating the old Activity; add isolated Python/JDK regression tests and negative controls; use clean temporary checkouts; and open the pair as drafts because real Android/EGL integration remains unverified under the r5.4 validation restrictions.
