### PR TITLE
Unblock the main thread on the EGL thread and make the renderer handover single use

### DIFF
--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -244,11 +244,6 @@ public abstract class MapRendererView extends FrameLayout {
         Log.v(TAG, "setupRenderer()");
         NativeCore.checkIfLoaded();
 
-        // The view owns a renderer again, whether it's a new one or one that is taken over.
-        // A view that handed its renderer over may well be set up again, as it happens when
-        // rendering comes back from Android Auto to the phone
-        isHandedOver = false;
-
         if (_mapRenderer != null) {
             synchronized (_mapRenderer) {
                 _exportableMapRenderer = null;
@@ -259,6 +254,17 @@ public abstract class MapRendererView extends FrameLayout {
                 }
                 removeRenderingView();
             }
+        }
+
+        if (isHandedOver) {
+            // The renderer and the EGL thread belong to the view that took them over, so they
+            // must be neither reused nor stopped here. The view owns a renderer again from now
+            // on: a new one, or one taken over in its turn, as it happens when rendering comes
+            // back from Android Auto to the phone
+            _mapRenderer = null;
+            eglThread = null;
+            isSuspended = false;
+            isHandedOver = false;
         }
 
         _inWindow = (bitmapWidth == 0 || bitmapHeight == 0);
@@ -282,6 +288,9 @@ public abstract class MapRendererView extends FrameLayout {
             isReinitializing = (isSuspended && _mapRenderer != null && _mapRenderer.isRenderingInitialized());
             if (!isReinitializing) {
                 Log.v(TAG, "Setting up new renderer to initialize...");
+                // Nothing of the present renderer is reused: its rendering is released by now,
+                // and its thread would otherwise be left waiting forever
+                stopEglThread();
                 eglThread = new EGLThread("OpenGLThread", this);
                 eglThread.start();
                 _mapRenderer = createMapRendererInstance();
@@ -297,6 +306,11 @@ public abstract class MapRendererView extends FrameLayout {
             if (_mapRenderer != oldRenderer && isSuspended && _mapRenderer.isRenderingInitialized()) {
                 Log.v(TAG, "Releasing suspended renderer...");
                 releaseSuspendedRenderer();
+            }
+            if (eglThread != oldView.eglThread) {
+                // The present thread is replaced by the one of the old view, so it has to be
+                // stopped, or it would be left waiting forever with its EGL contexts alive
+                stopEglThread();
             }
 
             // Use previous frame rate limit for battery saving mode

--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -197,6 +197,11 @@ public abstract class MapRendererView extends FrameLayout {
     private volatile boolean isSuspended;
 
     /**
+     * Renderer was handed over to another view, which owns it from now on
+     */
+    private volatile boolean isHandedOver;
+
+    /**
      * Target surface is present and ready for drawing
      */
     private volatile boolean isSurfaceReady;
@@ -239,6 +244,11 @@ public abstract class MapRendererView extends FrameLayout {
         Log.v(TAG, "setupRenderer()");
         NativeCore.checkIfLoaded();
 
+        // The view owns a renderer again, whether it's a new one or one that is taken over.
+        // A view that handed its renderer over may well be set up again, as it happens when
+        // rendering comes back from Android Auto to the phone
+        isHandedOver = false;
+
         if (_mapRenderer != null) {
             synchronized (_mapRenderer) {
                 _exportableMapRenderer = null;
@@ -265,7 +275,7 @@ public abstract class MapRendererView extends FrameLayout {
         setMaximumFrameRate(0);
 
         // Get already present renderer if available
-        IMapRenderer oldRenderer = oldView != null ? oldView.suspendRenderer() : null;
+        IMapRenderer oldRenderer = oldView != null ? oldView.exportRenderer() : null;
 
         if (oldRenderer == null) {
 
@@ -434,32 +444,59 @@ public abstract class MapRendererView extends FrameLayout {
 		return _frameReadingMode ? _flippedBitmap : _resultBitmap;
 	}
 
-    public synchronized IMapRenderer suspendRenderer() {
+    /**
+     * Suspends this view, keeping its renderer and EGL contexts initialized for a handover to
+     * another view. It has to be called before the view is detached, otherwise
+     * onDetachedFromWindow() releases rendering. Repeated calls are allowed until the renderer
+     * is exported. If no handover follows, the owner has to call {@link #stopRenderer()}
+     *
+     * @return whether a renderer is kept for a handover
+     */
+    public synchronized boolean suspendRenderer() {
         Log.v(TAG, "suspendRenderer()");
 
-        if (_mapRenderer == null || !_mapRenderer.isRenderingInitialized() || _exportableMapRenderer == null) {
-            return null;
+        if (_mapRenderer == null || !_mapRenderer.isRenderingInitialized()
+                || _exportableMapRenderer == null) {
+            return false;
         }
 
         synchronized (_mapRenderer) {
             stopRenderingView();
             if (isSuspended) {
                 Log.v(TAG, "Renderer was already suspended");
-                return null;
             } else {
                 Log.v(TAG, "Suspending renderer to reuse it in other view");
                 isSuspended = true;
                 isInitializing = false;
                 isReinitializing = false;
-            }
-            removeRenderingView();
+                removeRenderingView();
 
-            // Clean up data
-            listeners = new ArrayList<>();
-            _mapAnimator = null;
-            _mapMarkersAnimator = null;
+                // Clean up data
+                listeners = new ArrayList<>();
+                _mapAnimator = null;
+                _mapMarkersAnimator = null;
+            }
         }
-        return _exportableMapRenderer.isRenderingInitialized() ? _exportableMapRenderer : null;
+        return _exportableMapRenderer.isRenderingInitialized();
+    }
+
+    /**
+     * Hands the renderer of a suspended view over to another view. It's only possible once:
+     * the receiving view publishes an exportable renderer of its own after it initializes
+     * rendering on its surface
+     *
+     * @return renderer that is ready to be reused, or null if there's none
+     */
+    public synchronized IMapRenderer exportRenderer() {
+        Log.v(TAG, "exportRenderer()");
+
+        if (!suspendRenderer()) {
+            return null;
+        }
+        IMapRenderer renderer = _exportableMapRenderer;
+        _exportableMapRenderer = null;
+        isHandedOver = true;
+        return renderer;
     }
 
     public synchronized void stopRenderer() {
@@ -467,6 +504,14 @@ public abstract class MapRendererView extends FrameLayout {
 
         if (_mapRenderer == null) {
             Log.w(TAG, "Can't stop absent renderer");
+            return;
+        }
+
+        if (isHandedOver) {
+            // Renderer and EGL thread are owned by the view that took them over
+            Log.w(TAG, "Can't stop the renderer that was handed over");
+            _mapRenderer = null;
+            eglThread = null;
             return;
         }
 

--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -272,7 +272,7 @@ public abstract class MapRendererView extends FrameLayout {
             isReinitializing = (isSuspended && _mapRenderer != null && _mapRenderer.isRenderingInitialized());
             if (!isReinitializing) {
                 Log.v(TAG, "Setting up new renderer to initialize...");
-                eglThread = new EGLThread("OpenGLThread");
+                eglThread = new EGLThread("OpenGLThread", this);
                 eglThread.start();
                 _mapRenderer = createMapRendererInstance();
                 isInitializing = true;
@@ -301,6 +301,7 @@ public abstract class MapRendererView extends FrameLayout {
 
             // Take all EGL references from old map renderer view
             eglThread = oldView.eglThread;
+            eglThread.rendererView = this;
 
             // Reset rendering options for current view
             if (eglThread.gpuWorkerContext != null && eglThread.gpuWorkerFakeSurface != null) {
@@ -2546,7 +2547,13 @@ public abstract class MapRendererView extends FrameLayout {
         }
     }
 
-    private class EGLThread extends Thread {
+    private static class EGLThread extends Thread {
+
+        /**
+         * View that owns the thread now. The thread outlives a view that hands its renderer
+         * over, so it must never keep an implicit reference to the view that created it
+         */
+        protected volatile MapRendererView rendererView;
 
         private EGL10 egl;
         private EGLDisplay display;
@@ -2604,8 +2611,9 @@ public abstract class MapRendererView extends FrameLayout {
         private long completedOperations;
         public volatile long preFlushTime = SystemClock.uptimeMillis();
 
-        public EGLThread(String name) {
+        public EGLThread(String name, MapRendererView rendererView) {
             super(name);
+            this.rendererView = rendererView;
         }
 
         // NOTE: It needs to be called from synchronized block
@@ -2827,13 +2835,13 @@ public abstract class MapRendererView extends FrameLayout {
                         case RENDER_FRAME:
                         mapRenderer.update();
                         boolean isReady = mapRenderer.prepareFrame();
-                        _isRenderingActive = isReady ? mapRenderer.renderFrame() : false;
+                        rendererView._isRenderingActive = isReady ? mapRenderer.renderFrame() : false;
                         preFlushTime = SystemClock.uptimeMillis();
                         if (isReady) {
                             gl.glFlush();
                             if (byteBuffer != null) {
                                 gl.glFinish();
-                                if (_frameReadingMode) {
+                                if (rendererView._frameReadingMode) {
                                     egl.eglSwapBuffers(display, surface);
                                 }
                                 synchronized (byteBuffer) {
@@ -2849,10 +2857,10 @@ public abstract class MapRendererView extends FrameLayout {
                         break;
 
                         case RELEASE_RENDERING:
-                        _mapAnimationFinished = true;
-                        _mapMarkersAnimationFinished = true;
+                        rendererView._mapAnimationFinished = true;
+                        rendererView._mapMarkersAnimationFinished = true;
                         mapRenderer.releaseRendering(true);
-                        _isRenderingActive = false;
+                        rendererView._isRenderingActive = false;
                         break;
 
                         case DESTROY_SURFACE:

--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -59,8 +59,12 @@ import java.util.List;
 public abstract class MapRendererView extends FrameLayout {
     private static final String TAG = "OsmAndCore:Android/MapRendererView";
 
-    private final static long RELEASE_STOP_TIMEOUT = 4000;
-    private final static long RELEASE_WAIT_TIMEOUT = 50;
+    /**
+     * Maximum time the calling thread is allowed to be blocked while waiting for the EGL
+     * thread to release rendering or to stop. The EGL thread is abandoned when it doesn't
+     * manage to do that in time, so that the main thread never hangs on a stalled GPU driver
+     */
+    private final static long RELEASE_STOP_TIMEOUT = 1500;
 
     /**
      * Reference to OsmAndCore::IMapRenderer instance
@@ -212,9 +216,6 @@ public abstract class MapRendererView extends FrameLayout {
      */
     private volatile boolean initOnResume;
 
-    private volatile Runnable releaseTask;
-    private volatile boolean waitRelease;
-
     private List<MapRendererViewListener> listeners = new ArrayList<>();
 
     public interface MapRendererViewListener {
@@ -244,7 +245,7 @@ public abstract class MapRendererView extends FrameLayout {
                 stopRenderingView();
                 if (!isSuspended && _mapRenderer.isRenderingInitialized()) {
                     Log.v(TAG, "Rendering release due to setupRenderer()");
-                    releaseRendering();
+                    releaseRendering(RELEASE_STOP_TIMEOUT);
                 }
                 removeRenderingView();
             }
@@ -285,10 +286,7 @@ public abstract class MapRendererView extends FrameLayout {
 
             if (_mapRenderer != oldRenderer && isSuspended && _mapRenderer.isRenderingInitialized()) {
                 Log.v(TAG, "Releasing suspended renderer...");
-                synchronized (eglThread) {
-                    eglThread.mapRenderer = _mapRenderer;
-                    eglThread.startAndCompleteOperation(EGLThreadOperation.RELEASE_RENDERING);
-                }
+                releaseSuspendedRenderer();
             }
 
             // Use previous frame rate limit for battery saving mode
@@ -475,15 +473,12 @@ public abstract class MapRendererView extends FrameLayout {
             if (isSuspended) {
                 if (_mapRenderer.isRenderingInitialized()) {
                     Log.v(TAG, "Stopping suspended renderer...");
-                    synchronized (eglThread) {
-                        eglThread.mapRenderer = _mapRenderer;
-                        eglThread.startAndCompleteOperation(EGLThreadOperation.RELEASE_RENDERING);
-                    }
+                    releaseSuspendedRenderer();
                 }
             } else {
                 Log.v(TAG, "Stopping active renderer...");
                 stopRenderingView();
-                releaseRendering();
+                releaseRendering(RELEASE_STOP_TIMEOUT);
                 removeRenderingView();
             }
             // Clean up data
@@ -492,31 +487,99 @@ public abstract class MapRendererView extends FrameLayout {
             _mapMarkersAnimator = null;
         }
 
-        if (eglThread != null) {
-            synchronized (eglThread) {
-                eglThread.stopThread = true;
-                eglThread.notifyAll();
-                while (!eglThread.isStopped) {
-                    try {
-                        eglThread.wait();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
+        stopEglThread();
+    }
+
+    // NOTE: Zero timeout means waiting for the rendering to be released indefinitely. That's
+    // only safe for the calls made from the rendering view thread, which has no frame in flight
+    // while it creates or destroys an EGL context
+    private void releaseRendering() {
+        releaseRendering(0);
+    }
+
+    private void releaseRendering(long timeout) {
+        Log.v(TAG, "releaseRendering()");
+        EGLThread thread = eglThread;
+        if (thread != null && !isSuspended && _mapRenderer != null
+                && _mapRenderer.isRenderingInitialized()) {
+            Log.v(TAG, "Release rendering...");
+            boolean released;
+            synchronized (thread) {
+                thread.mapRenderer = _mapRenderer;
+                released = thread.startAndCompleteOperation(
+                    EGLThreadOperation.RELEASE_RENDERING, timeout);
             }
-            eglThread = null;
+            if (!released && timeout > 0) {
+                abandonEglThread(thread);
+            }
         }
     }
 
-    private void releaseRendering() {
-        Log.v(TAG, "releaseRendering()");
-        if (!isSuspended && _mapRenderer != null && _mapRenderer.isRenderingInitialized()) {
-            Log.v(TAG, "Release rendering...");
-            synchronized (eglThread) {
-                eglThread.mapRenderer = _mapRenderer;
-                eglThread.startAndCompleteOperation(EGLThreadOperation.RELEASE_RENDERING);
+    // NOTE: Rendering of a suspended renderer is released by the EGL thread that keeps it,
+    // since the rendering view of this view is already gone
+    private void releaseSuspendedRenderer() {
+        EGLThread thread = eglThread;
+        if (thread == null) {
+            return;
+        }
+        boolean released;
+        synchronized (thread) {
+            thread.mapRenderer = _mapRenderer;
+            released = thread.startAndCompleteOperation(
+                EGLThreadOperation.RELEASE_RENDERING, RELEASE_STOP_TIMEOUT);
+        }
+        if (!released) {
+            abandonEglThread(thread);
+        }
+    }
+
+    private void stopEglThread() {
+        EGLThread thread = eglThread;
+        if (thread == null) {
+            return;
+        }
+        if (!thread.abandoned) {
+            synchronized (thread) {
+                thread.stopThread = true;
+                thread.notifyAll();
+                long deadline = SystemClock.uptimeMillis() + RELEASE_STOP_TIMEOUT;
+                while (!thread.isStopped) {
+                    long timeToWait = deadline - SystemClock.uptimeMillis();
+                    if (timeToWait <= 0) {
+                        Log.e(TAG, "EGL thread didn't stop in time, abandoning it");
+                        thread.abandoned = true;
+                        break;
+                    }
+                    try {
+                        thread.wait(timeToWait);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
             }
         }
+        eglThread = null;
+    }
+
+    /**
+     * Gives up on an EGL thread that is stuck inside a GPU driver call. It stops and destroys
+     * its EGL resources by itself once that call returns, and every operation requested from
+     * it in the meantime returns at once. The renderer is left to it, because the operation
+     * that didn't complete may still be using it.
+     *
+     * The thread stays referenced on purpose: the rendering view thread still locks it while
+     * it tears its own EGL context down, which happens right after this on the destroy path
+     */
+    private void abandonEglThread(EGLThread thread) {
+        Log.e(TAG, "EGL thread didn't complete the operation in time, abandoning it");
+        synchronized (thread) {
+            thread.abandoned = true;
+            thread.stopThread = true;
+            thread.notifyAll();
+        }
+        _exportableMapRenderer = null;
+        _mapRenderer = null;
     }
 
     public void startRenderingView(Context context) {
@@ -588,7 +651,7 @@ public abstract class MapRendererView extends FrameLayout {
             // Surface and context are going to be destroyed, thus try to release rendering
             // before that will happen
             Log.v(TAG, "Rendering release due to onDetachedFromWindow()");
-            releaseRendering();
+            releaseRendering(RELEASE_STOP_TIMEOUT);
         }
 
         super.onDetachedFromWindow();
@@ -614,7 +677,7 @@ public abstract class MapRendererView extends FrameLayout {
             // Map renderer will be automatically deleted by GC anyways. But queue
             // action to release rendering
             Log.v(TAG, "Rendering release due to handleOnDestroy()");
-            releaseRendering();
+            releaseRendering(RELEASE_STOP_TIMEOUT);
         }
     }
 
@@ -2508,6 +2571,7 @@ public abstract class MapRendererView extends FrameLayout {
         protected volatile boolean renderingResultIsReady;
         protected volatile boolean stopThread;
         protected volatile boolean isStopped;
+        protected volatile boolean abandoned;
 
         private final int EGL_CONTEXT_CLIENT_VERSION = 0x3098;
 
@@ -2531,6 +2595,13 @@ public abstract class MapRendererView extends FrameLayout {
 
         public volatile EGLThreadOperation eglThreadOperation = EGLThreadOperation.NO_OPERATION;
         public volatile boolean ok;
+
+        /**
+         * Operations dispatched to the thread and completed by it, guarded by the monitor.
+         * They let a caller wait for its own operation rather than for the thread to be idle
+         */
+        private long dispatchedOperations;
+        private long completedOperations;
         public volatile long preFlushTime = SystemClock.uptimeMillis();
 
         public EGLThread(String name) {
@@ -2539,23 +2610,83 @@ public abstract class MapRendererView extends FrameLayout {
 
         // NOTE: It needs to be called from synchronized block
         public void startAndCompleteOperation(EGLThreadOperation operation) {
-            eglThreadOperation = operation;
-            notifyAll();
-            while (eglThreadOperation != EGLThreadOperation.NO_OPERATION) {
-                try {
-                    wait();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+            startAndCompleteOperation(operation, 0);
+        }
+
+        /**
+         * Starts an operation on the EGL thread and waits for it to be completed.
+         *
+         * NOTE: It needs to be called from synchronized block
+         *
+         * @param operation operation to be performed
+         * @param timeout maximum time to wait for the operation to be completed, in
+         *                milliseconds. Zero means waiting for it indefinitely, which is
+         *                only safe when the calling thread is not the main one
+         * @return whether the operation was completed
+         */
+        public boolean startAndCompleteOperation(EGLThreadOperation operation, long timeout) {
+            long deadline = timeout > 0 ? SystemClock.uptimeMillis() + timeout : 0;
+            // Another operation may still be in flight, since the monitor is released
+            // while the EGL thread performs one. A stopped or abandoned thread is never
+            // waited for: it's not going to complete anything for the caller
+            while (completedOperations < dispatchedOperations) {
+                if (stopThread || !awaitOperation(deadline)) {
+                    return false;
                 }
             }
+            if (stopThread || isStopped) {
+                Log.w(TAG, "Can't perform an operation on the stopped EGL thread");
+                return false;
+            }
+            long serial = ++dispatchedOperations;
+            eglThreadOperation = operation;
+            notifyAll();
+            while (completedOperations < serial) {
+                if (stopThread || !awaitOperation(deadline)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // NOTE: It needs to be called from synchronized block
+        private boolean awaitOperation(long deadline) {
+            long timeToWait = 0;
+            if (deadline > 0) {
+                timeToWait = deadline - SystemClock.uptimeMillis();
+                if (timeToWait <= 0) {
+                    return false;
+                }
+            }
+            try {
+                wait(timeToWait);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+            return true;
         }
 
         @Override
         public void run() {
             egl = (EGL10) EGLContext.getEGL();
             while (!stopThread) {
+                EGLThreadOperation operation;
                 synchronized (this) {
-                    switch (eglThreadOperation) {
+                    while (eglThreadOperation == EGLThreadOperation.NO_OPERATION && !stopThread) {
+                        try {
+                            wait();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                    operation = eglThreadOperation;
+                }
+                if (operation != EGLThreadOperation.NO_OPERATION) {
+                    // NOTE: An operation is performed with the monitor released, so that a
+                    // caller that gave up waiting for it is able to return, instead of being
+                    // blocked on the monitor until a stalled GPU driver call returns
+                    switch (operation) {
                         case CHOOSE_CONFIG:
                         if (display == null) {
                             display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
@@ -2735,44 +2866,59 @@ public abstract class MapRendererView extends FrameLayout {
                         break;
 
                         case DESTROY_CONTEXTS:
-                        if (display != null) {
-                            // Destroy main context
-                            if (context != null) {
-                                egl.eglDestroyContext(display, context);
-                                context = null;
-                            }
-                            // Destroy GPU-worker EGL surface (if present)
-                            if (gpuWorkerFakeSurface != null) {
-                                egl.eglDestroySurface(display, gpuWorkerFakeSurface);
-                                gpuWorkerFakeSurface = null;
-                            }
-                            // Destroy GPU-worker EGL context (if present)
-                            if (gpuWorkerContext != null) {
-                                egl.eglDestroyContext(display, gpuWorkerContext);
-                                gpuWorkerContext = null;
-                            }
-                            // Remove EGL config
-                            if (config != null) {
-                                config = null;
-                            }
-                            // Terminate connection to EGL display
-                            egl.eglTerminate(display);
-                            display = null;
-                        }
+                        destroyEglResources();
+                        break;
                     }
-                    eglThreadOperation = EGLThreadOperation.NO_OPERATION;
-                    notifyAll();
-                    try {
-                        wait();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+                    synchronized (this) {
+                        eglThreadOperation = EGLThreadOperation.NO_OPERATION;
+                        completedOperations++;
+                        notifyAll();
                     }
                 }
             }
+            // An abandoned thread is the only owner of its EGL resources left
+            destroyEglResources();
             synchronized (this) {
                 isStopped = true;
                 notifyAll();
             }
+        }
+
+        // NOTE: It's called from the EGL thread only
+        private void destroyEglResources() {
+            if (display == null) {
+                return;
+            }
+            // Destroy rendering surface (if present)
+            if (surface != null) {
+                egl.eglMakeCurrent(display, EGL10.EGL_NO_SURFACE,
+                    EGL10.EGL_NO_SURFACE,
+                    EGL10.EGL_NO_CONTEXT);
+                egl.eglDestroySurface(display, surface);
+                surface = null;
+            }
+            // Destroy main context
+            if (context != null) {
+                egl.eglDestroyContext(display, context);
+                context = null;
+            }
+            // Destroy GPU-worker EGL surface (if present)
+            if (gpuWorkerFakeSurface != null) {
+                egl.eglDestroySurface(display, gpuWorkerFakeSurface);
+                gpuWorkerFakeSurface = null;
+            }
+            // Destroy GPU-worker EGL context (if present)
+            if (gpuWorkerContext != null) {
+                egl.eglDestroyContext(display, gpuWorkerContext);
+                gpuWorkerContext = null;
+            }
+            // Remove EGL config
+            if (config != null) {
+                config = null;
+            }
+            // Terminate connection to EGL display
+            egl.eglTerminate(display);
+            display = null;
         }
     }
 }


### PR DESCRIPTION
Four commits against `master`, in one file. The first one is the ANR fix, the next two make a
renderer handover across an activity recreation possible and correct, and the last one fixes a
pre-existing leak in `setupRenderer()` that the handover work made visible. The app-side change that
uses the handover is [osmandapp/OsmAnd#25926](https://github.com/osmandapp/OsmAnd/pull/25926): merge this one first, rebuild and publish the wrapper
artifacts, then merge that one.

Separate proposal from #1104 and #1110. Neither is modified or closed.

## 1. Don't block the main thread on the EGL thread without a deadline

`EGLThread.run()` held its own monitor for the whole `switch`:

```java
while (!stopThread) {
    synchronized (this) {
        switch (eglThreadOperation) { ... RENDER_FRAME / RELEASE_RENDERING ... }
        eglThreadOperation = NO_OPERATION;
        notifyAll();
        wait();
    }
}
```

So every caller of `startAndCompleteOperation()` blocked on entering `synchronized (eglThread)`
while the thread was inside a GPU driver call, and `startAndCompleteOperation()` itself waited
without a timeout. Adding a `wait()` timeout alone does not help, because `wait()` has to
reacquire the monitor before it can return. That is the reason #1104 concluded the waits can't
be bounded - the conclusion is right, the monitor is what has to be fixed.

An operation is now performed with the monitor released, so the monitor only guards the state
handover, and the main thread gets a deadline:

- `startAndCompleteOperation(operation, timeout)` returns whether the operation completed. Zero
  timeout keeps the old behavior and is used by the rendering view thread only, which has no
  frame in flight while it creates or destroys an EGL context.
- `releaseRendering()`, `stopRenderer()` and `setupRenderer()` wait for at most
  `RELEASE_STOP_TIMEOUT` and then abandon the EGL thread instead of hanging. An abandoned thread
  stops as soon as the driver call returns; the renderer is left to it, because the operation
  that didn't complete may still be using it. The thread stays referenced on purpose: right after
  the abandon, `removeRenderingView()` detaches the `GLSurfaceView`, whose thread still locks
  `eglThread` in `destroySurface()`/`destroyContext()` - every operation requested from an
  abandoned or stopped thread returns at once, so that teardown neither NPEs nor blocks.
- A caller waits for its own operation (dispatched/completed counters), not for the thread to
  become idle, so a second caller dispatching right after doesn't extend the first one's wait.
- The EGL thread destroys its own EGL resources before it exits. That also fixes an existing
  leak: `DESTROY_CONTEXTS` is only ever requested from `EGLContextFactory.destroyContext()` under
  `if (!isSuspended)`, so a suspended view that is stopped without a handover left its display
  and contexts alive.

History note: this wait used to be asynchronous (`scheduleReleaseRendering()` with
`queueEvent()`), then bounded by 4000 ms in 42d9a208, and lost the bound when it moved to
`EGLThread`. `RELEASE_STOP_TIMEOUT`, `RELEASE_WAIT_TIMEOUT`, `releaseTask` and `waitRelease` were
still in the file, unused. One of them is reused here with a value that leaves room for the
`GLSurfaceView` pause that precedes it; the rest are removed.

What this does **not** fix: `GLSurfaceView.onPause()` and `requestExitAndWait()` are AOSP code
and still wait for the frame in flight. That wait is one frame, not a full
`releaseRendering(true)`.

## 2. Keep an explicit owner view in the EGL thread

`EGLThread` was an inner class, so it captured the view that created it. The thread outlives that
view on every handover - which Android Auto transitions already do today. After a handover the
thread keeps writing `_isRenderingActive`, `_mapAnimationFinished` and
`_mapMarkersAnimationFinished` to the view that is gone, reads `_frameReadingMode` from it, and
keeps that view - and the activity behind it - alive for as long as rendering lasts.

The thread is now static and holds the current view explicitly, updated when `setupRenderer()`
takes the thread over. Only those four fields were reached through the implicit reference;
`TAG` and `getEglErrorString()` are static.

## 3. Let a renderer be suspended before it is handed over, and only once

`setupRenderer(context, w, h, oldView)` suspends the old view and takes its renderer in one step.
An activity that is being recreated has to suspend earlier, before the old view hierarchy is
detached, otherwise `onDetachedFromWindow()` sees a ready surface and releases rendering. A
second `suspendRenderer()` returned `null`, so the replacement view could not take an already
suspended renderer.

- `suspendRenderer()` suspends the view and reports whether a renderer is kept. Idempotent, so it
  can be called in advance and again by the handover.
- `exportRenderer()` hands the renderer over once and clears the exportable reference, so a stale
  view can't export the same renderer twice.
- `stopRenderer()` on a view that already handed its renderer over drops its references instead
  of releasing a renderer and stopping an EGL thread that belong to another view now.
  `setupRenderer()` clears that state, since a view that handed its renderer over is set up again
  when rendering comes back from Android Auto to the phone.

The wrapper does not decide which lifecycle events allow a handover. That stays with the caller.

## 4. Stop the EGL thread that `setupRenderer()` replaces

`setupRenderer()` replaced the view's EGL thread without stopping it, in three cases:

- no renderer to take over and nothing to reinitialize: a new thread was created over the present
  one, whose rendering had been released by then - it was left waiting forever. The development
  plugin's `recreateRenderer()` hits this on every call;
- a renderer taken over from another view while this view has a thread of its own: the old view's
  thread replaced it. For a suspended view the EGL contexts were still alive too, since
  `DESTROY_CONTEXTS` is only requested from the rendering view thread, which never runs for a
  suspended view;
- a view that handed its renderer over still referenced the renderer and the thread, and would
  treat a suspended initialized renderer as its own to reinitialize - two views owning one
  renderer. Nothing calls `setupRenderer()` on such a view without an old view today.

The present thread is stopped when it is not the one being taken over, and a view that handed its
renderer over drops its references before it is set up again.

## Validation

Nothing here was compiled or run. What was done is static: `git diff --check`, a brace-balance
check of the file, and a scan of the `EGLThread` body confirming that after commit 2 it
references no instance member of the enclosing class (only `MapRendererView` as a type and the
static `getEglErrorString`), which is what makes `static` legal.

Do not merge before a build and a device run. What needs to be checked:

- repeated rotations and `recreate()` with a visible map, background/resume, lock/unlock, final
  destruction, Android Auto connect/disconnect in both directions;
- that the same renderer and EGL thread are reused, frames continue on the new view, and ordinary
  destruction still releases and stops;
- the abandon path: an artificially stalled frame (the 3000 ms per-frame stall harness from
  #1104 works for this) plus a destroy, confirming the main thread returns on the deadline, the
  process stays alive, and the abandoned thread exits and terminates its EGL display afterwards;
- no ANR and no native crash across a rotation loop.

Any timing numbers should be taken on a real device. The emulator figures in #1104/#25866 come
from a software GPU, where re-initialization is disproportionately expensive.

The commits are separable: the first one stands on its own as the ANR fix, the second and third
are the handover and are only useful together with the app-side change, the fourth is a leak
fix that builds on the third.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Review #25866 and #25921 and say whether either is right or it should be done differently.
2. No manifest flags. Propose a new correct solution.
3. Three commits, one pull request.
4. Target `master` instead of `r5.4`.
5. Does this break Android Auto? Then: fix the leak found while checking that.

Decided by the agent, not requested explicitly: that the EGL thread monitor, not renderer reuse,
is the root cause, and that releasing it is the actual ANR fix; abandoning a stalled thread
rather than bounding it any other way; making the thread destroy its own EGL resources on exit;
the `isHandedOver` guard in `stopRenderer()` and its reset in `setupRenderer()`; the split of
`suspendRenderer()` and `exportRenderer()`; keeping the app-side change out of this PR; and
opening it as a draft because nothing was built or run.
