### PR TITLE
Bound the main thread's wait on the EGL thread, and fix renderer ownership on setup/stop (backport of #1114)

### DIFF
--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -197,6 +197,11 @@ public abstract class MapRendererView extends FrameLayout {
     private volatile boolean isSuspended;
 
     /**
+     * Renderer was handed over to another view, which owns it from now on
+     */
+    private volatile boolean isHandedOver;
+
+    /**
      * Target surface is present and ready for drawing
      */
     private volatile boolean isSurfaceReady;
@@ -251,6 +256,17 @@ public abstract class MapRendererView extends FrameLayout {
             }
         }
 
+        if (isHandedOver) {
+            // The renderer and the EGL thread belong to the view that took them over, so they
+            // must be neither reused nor stopped here. The view owns a renderer again from now
+            // on: a new one, or one taken over in its turn, as it happens when rendering comes
+            // back from Android Auto to the phone
+            _mapRenderer = null;
+            eglThread = null;
+            isSuspended = false;
+            isHandedOver = false;
+        }
+
         _inWindow = (bitmapWidth == 0 || bitmapHeight == 0);
 
         _windowWidth = bitmapWidth;
@@ -266,12 +282,18 @@ public abstract class MapRendererView extends FrameLayout {
 
         // Get already present renderer if available
         IMapRenderer oldRenderer = oldView != null ? oldView.suspendRenderer() : null;
+        if (oldRenderer != null) {
+            oldView.rendererWasHandedOver();
+        }
 
         if (oldRenderer == null) {
 
             isReinitializing = (isSuspended && _mapRenderer != null && _mapRenderer.isRenderingInitialized());
             if (!isReinitializing) {
                 Log.v(TAG, "Setting up new renderer to initialize...");
+                // Nothing of the present renderer is reused: its rendering is released by now,
+                // and its thread would otherwise be left waiting forever
+                stopEglThread();
                 eglThread = new EGLThread("OpenGLThread");
                 eglThread.start();
                 _mapRenderer = createMapRendererInstance();
@@ -288,6 +310,12 @@ public abstract class MapRendererView extends FrameLayout {
                 Log.v(TAG, "Releasing suspended renderer...");
                 releaseSuspendedRenderer();
             }
+            if (eglThread != oldView.eglThread) {
+                // The present thread is replaced by the one of the old view, so it has to be
+                // stopped, or it would be left waiting forever with its EGL contexts alive
+                stopEglThread();
+            }
+
             // Use previous frame rate limit for battery saving mode
             setMaximumFrameRate(oldView.getMaximumFrameRate());
 
@@ -460,11 +488,29 @@ public abstract class MapRendererView extends FrameLayout {
         return _exportableMapRenderer.isRenderingInitialized() ? _exportableMapRenderer : null;
     }
 
+    /**
+     * Marks a view whose renderer has just been taken over by another one. Its renderer and its
+     * EGL thread belong to that view from now on, so {@link #stopRenderer()} must not release
+     * them, and the same renderer can't be handed over a second time
+     */
+    private synchronized void rendererWasHandedOver() {
+        _exportableMapRenderer = null;
+        isHandedOver = true;
+    }
+
     public synchronized void stopRenderer() {
         Log.v(TAG, "stopRenderer()");
 
         if (_mapRenderer == null) {
             Log.w(TAG, "Can't stop absent renderer");
+            return;
+        }
+
+        if (isHandedOver) {
+            // Renderer and EGL thread are owned by the view that took them over
+            Log.w(TAG, "Can't stop the renderer that was handed over");
+            _mapRenderer = null;
+            eglThread = null;
             return;
         }
 

--- a/wrappers/android/src/net/osmand/core/android/MapRendererView.java
+++ b/wrappers/android/src/net/osmand/core/android/MapRendererView.java
@@ -59,8 +59,12 @@ import java.util.List;
 public abstract class MapRendererView extends FrameLayout {
     private static final String TAG = "OsmAndCore:Android/MapRendererView";
 
-    private final static long RELEASE_STOP_TIMEOUT = 4000;
-    private final static long RELEASE_WAIT_TIMEOUT = 50;
+    /**
+     * Maximum time the calling thread is allowed to be blocked while waiting for the EGL
+     * thread to release rendering or to stop. The EGL thread is abandoned when it doesn't
+     * manage to do that in time, so that the main thread never hangs on a stalled GPU driver
+     */
+    private final static long RELEASE_STOP_TIMEOUT = 1500;
 
     /**
      * Reference to OsmAndCore::IMapRenderer instance
@@ -212,9 +216,6 @@ public abstract class MapRendererView extends FrameLayout {
      */
     private volatile boolean initOnResume;
 
-    private volatile Runnable releaseTask;
-    private volatile boolean waitRelease;
-
     private List<MapRendererViewListener> listeners = new ArrayList<>();
 
     public interface MapRendererViewListener {
@@ -244,7 +245,7 @@ public abstract class MapRendererView extends FrameLayout {
                 stopRenderingView();
                 if (!isSuspended && _mapRenderer.isRenderingInitialized()) {
                     Log.v(TAG, "Rendering release due to setupRenderer()");
-                    releaseRendering();
+                    releaseRendering(RELEASE_STOP_TIMEOUT);
                 }
                 removeRenderingView();
             }
@@ -285,12 +286,8 @@ public abstract class MapRendererView extends FrameLayout {
 
             if (_mapRenderer != oldRenderer && isSuspended && _mapRenderer.isRenderingInitialized()) {
                 Log.v(TAG, "Releasing suspended renderer...");
-                synchronized (eglThread) {
-                    eglThread.mapRenderer = _mapRenderer;
-                    eglThread.startAndCompleteOperation(EGLThreadOperation.RELEASE_RENDERING);
-                }
+                releaseSuspendedRenderer();
             }
-
             // Use previous frame rate limit for battery saving mode
             setMaximumFrameRate(oldView.getMaximumFrameRate());
 
@@ -475,15 +472,12 @@ public abstract class MapRendererView extends FrameLayout {
             if (isSuspended) {
                 if (_mapRenderer.isRenderingInitialized()) {
                     Log.v(TAG, "Stopping suspended renderer...");
-                    synchronized (eglThread) {
-                        eglThread.mapRenderer = _mapRenderer;
-                        eglThread.startAndCompleteOperation(EGLThreadOperation.RELEASE_RENDERING);
-                    }
+                    releaseSuspendedRenderer();
                 }
             } else {
                 Log.v(TAG, "Stopping active renderer...");
                 stopRenderingView();
-                releaseRendering();
+                releaseRendering(RELEASE_STOP_TIMEOUT);
                 removeRenderingView();
             }
             // Clean up data
@@ -492,31 +486,99 @@ public abstract class MapRendererView extends FrameLayout {
             _mapMarkersAnimator = null;
         }
 
-        if (eglThread != null) {
-            synchronized (eglThread) {
-                eglThread.stopThread = true;
-                eglThread.notifyAll();
-                while (!eglThread.isStopped) {
-                    try {
-                        eglThread.wait();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
+        stopEglThread();
+    }
+
+    // NOTE: Zero timeout means waiting for the rendering to be released indefinitely. That's
+    // only safe for the calls made from the rendering view thread, which has no frame in flight
+    // while it creates or destroys an EGL context
+    private void releaseRendering() {
+        releaseRendering(0);
+    }
+
+    private void releaseRendering(long timeout) {
+        Log.v(TAG, "releaseRendering()");
+        EGLThread thread = eglThread;
+        if (thread != null && !isSuspended && _mapRenderer != null
+                && _mapRenderer.isRenderingInitialized()) {
+            Log.v(TAG, "Release rendering...");
+            boolean released;
+            synchronized (thread) {
+                thread.mapRenderer = _mapRenderer;
+                released = thread.startAndCompleteOperation(
+                    EGLThreadOperation.RELEASE_RENDERING, timeout);
             }
-            eglThread = null;
+            if (!released && timeout > 0) {
+                abandonEglThread(thread);
+            }
         }
     }
 
-    private void releaseRendering() {
-        Log.v(TAG, "releaseRendering()");
-        if (!isSuspended && _mapRenderer != null && _mapRenderer.isRenderingInitialized()) {
-            Log.v(TAG, "Release rendering...");
-            synchronized (eglThread) {
-                eglThread.mapRenderer = _mapRenderer;
-                eglThread.startAndCompleteOperation(EGLThreadOperation.RELEASE_RENDERING);
+    // NOTE: Rendering of a suspended renderer is released by the EGL thread that keeps it,
+    // since the rendering view of this view is already gone
+    private void releaseSuspendedRenderer() {
+        EGLThread thread = eglThread;
+        if (thread == null) {
+            return;
+        }
+        boolean released;
+        synchronized (thread) {
+            thread.mapRenderer = _mapRenderer;
+            released = thread.startAndCompleteOperation(
+                EGLThreadOperation.RELEASE_RENDERING, RELEASE_STOP_TIMEOUT);
+        }
+        if (!released) {
+            abandonEglThread(thread);
+        }
+    }
+
+    private void stopEglThread() {
+        EGLThread thread = eglThread;
+        if (thread == null) {
+            return;
+        }
+        if (!thread.abandoned) {
+            synchronized (thread) {
+                thread.stopThread = true;
+                thread.notifyAll();
+                long deadline = SystemClock.uptimeMillis() + RELEASE_STOP_TIMEOUT;
+                while (!thread.isStopped) {
+                    long timeToWait = deadline - SystemClock.uptimeMillis();
+                    if (timeToWait <= 0) {
+                        Log.e(TAG, "EGL thread didn't stop in time, abandoning it");
+                        thread.abandoned = true;
+                        break;
+                    }
+                    try {
+                        thread.wait(timeToWait);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
             }
         }
+        eglThread = null;
+    }
+
+    /**
+     * Gives up on an EGL thread that is stuck inside a GPU driver call. It stops and destroys
+     * its EGL resources by itself once that call returns, and every operation requested from
+     * it in the meantime returns at once. The renderer is left to it, because the operation
+     * that didn't complete may still be using it.
+     *
+     * The thread stays referenced on purpose: the rendering view thread still locks it while
+     * it tears its own EGL context down, which happens right after this on the destroy path
+     */
+    private void abandonEglThread(EGLThread thread) {
+        Log.e(TAG, "EGL thread didn't complete the operation in time, abandoning it");
+        synchronized (thread) {
+            thread.abandoned = true;
+            thread.stopThread = true;
+            thread.notifyAll();
+        }
+        _exportableMapRenderer = null;
+        _mapRenderer = null;
     }
 
     public void startRenderingView(Context context) {
@@ -588,7 +650,7 @@ public abstract class MapRendererView extends FrameLayout {
             // Surface and context are going to be destroyed, thus try to release rendering
             // before that will happen
             Log.v(TAG, "Rendering release due to onDetachedFromWindow()");
-            releaseRendering();
+            releaseRendering(RELEASE_STOP_TIMEOUT);
         }
 
         super.onDetachedFromWindow();
@@ -614,7 +676,7 @@ public abstract class MapRendererView extends FrameLayout {
             // Map renderer will be automatically deleted by GC anyways. But queue
             // action to release rendering
             Log.v(TAG, "Rendering release due to handleOnDestroy()");
-            releaseRendering();
+            releaseRendering(RELEASE_STOP_TIMEOUT);
         }
     }
 
@@ -2508,6 +2570,7 @@ public abstract class MapRendererView extends FrameLayout {
         protected volatile boolean renderingResultIsReady;
         protected volatile boolean stopThread;
         protected volatile boolean isStopped;
+        protected volatile boolean abandoned;
 
         private final int EGL_CONTEXT_CLIENT_VERSION = 0x3098;
 
@@ -2531,6 +2594,13 @@ public abstract class MapRendererView extends FrameLayout {
 
         public volatile EGLThreadOperation eglThreadOperation = EGLThreadOperation.NO_OPERATION;
         public volatile boolean ok;
+
+        /**
+         * Operations dispatched to the thread and completed by it, guarded by the monitor.
+         * They let a caller wait for its own operation rather than for the thread to be idle
+         */
+        private long dispatchedOperations;
+        private long completedOperations;
         public volatile long preFlushTime = SystemClock.uptimeMillis();
 
         public EGLThread(String name) {
@@ -2539,23 +2609,83 @@ public abstract class MapRendererView extends FrameLayout {
 
         // NOTE: It needs to be called from synchronized block
         public void startAndCompleteOperation(EGLThreadOperation operation) {
-            eglThreadOperation = operation;
-            notifyAll();
-            while (eglThreadOperation != EGLThreadOperation.NO_OPERATION) {
-                try {
-                    wait();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+            startAndCompleteOperation(operation, 0);
+        }
+
+        /**
+         * Starts an operation on the EGL thread and waits for it to be completed.
+         *
+         * NOTE: It needs to be called from synchronized block
+         *
+         * @param operation operation to be performed
+         * @param timeout maximum time to wait for the operation to be completed, in
+         *                milliseconds. Zero means waiting for it indefinitely, which is
+         *                only safe when the calling thread is not the main one
+         * @return whether the operation was completed
+         */
+        public boolean startAndCompleteOperation(EGLThreadOperation operation, long timeout) {
+            long deadline = timeout > 0 ? SystemClock.uptimeMillis() + timeout : 0;
+            // Another operation may still be in flight, since the monitor is released
+            // while the EGL thread performs one. A stopped or abandoned thread is never
+            // waited for: it's not going to complete anything for the caller
+            while (completedOperations < dispatchedOperations) {
+                if (stopThread || !awaitOperation(deadline)) {
+                    return false;
                 }
             }
+            if (stopThread || isStopped) {
+                Log.w(TAG, "Can't perform an operation on the stopped EGL thread");
+                return false;
+            }
+            long serial = ++dispatchedOperations;
+            eglThreadOperation = operation;
+            notifyAll();
+            while (completedOperations < serial) {
+                if (stopThread || !awaitOperation(deadline)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // NOTE: It needs to be called from synchronized block
+        private boolean awaitOperation(long deadline) {
+            long timeToWait = 0;
+            if (deadline > 0) {
+                timeToWait = deadline - SystemClock.uptimeMillis();
+                if (timeToWait <= 0) {
+                    return false;
+                }
+            }
+            try {
+                wait(timeToWait);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+            return true;
         }
 
         @Override
         public void run() {
             egl = (EGL10) EGLContext.getEGL();
             while (!stopThread) {
+                EGLThreadOperation operation;
                 synchronized (this) {
-                    switch (eglThreadOperation) {
+                    while (eglThreadOperation == EGLThreadOperation.NO_OPERATION && !stopThread) {
+                        try {
+                            wait();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                    operation = eglThreadOperation;
+                }
+                if (operation != EGLThreadOperation.NO_OPERATION) {
+                    // NOTE: An operation is performed with the monitor released, so that a
+                    // caller that gave up waiting for it is able to return, instead of being
+                    // blocked on the monitor until a stalled GPU driver call returns
+                    switch (operation) {
                         case CHOOSE_CONFIG:
                         if (display == null) {
                             display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
@@ -2735,44 +2865,59 @@ public abstract class MapRendererView extends FrameLayout {
                         break;
 
                         case DESTROY_CONTEXTS:
-                        if (display != null) {
-                            // Destroy main context
-                            if (context != null) {
-                                egl.eglDestroyContext(display, context);
-                                context = null;
-                            }
-                            // Destroy GPU-worker EGL surface (if present)
-                            if (gpuWorkerFakeSurface != null) {
-                                egl.eglDestroySurface(display, gpuWorkerFakeSurface);
-                                gpuWorkerFakeSurface = null;
-                            }
-                            // Destroy GPU-worker EGL context (if present)
-                            if (gpuWorkerContext != null) {
-                                egl.eglDestroyContext(display, gpuWorkerContext);
-                                gpuWorkerContext = null;
-                            }
-                            // Remove EGL config
-                            if (config != null) {
-                                config = null;
-                            }
-                            // Terminate connection to EGL display
-                            egl.eglTerminate(display);
-                            display = null;
-                        }
+                        destroyEglResources();
+                        break;
                     }
-                    eglThreadOperation = EGLThreadOperation.NO_OPERATION;
-                    notifyAll();
-                    try {
-                        wait();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+                    synchronized (this) {
+                        eglThreadOperation = EGLThreadOperation.NO_OPERATION;
+                        completedOperations++;
+                        notifyAll();
                     }
                 }
             }
+            // An abandoned thread is the only owner of its EGL resources left
+            destroyEglResources();
             synchronized (this) {
                 isStopped = true;
                 notifyAll();
             }
+        }
+
+        // NOTE: It's called from the EGL thread only
+        private void destroyEglResources() {
+            if (display == null) {
+                return;
+            }
+            // Destroy rendering surface (if present)
+            if (surface != null) {
+                egl.eglMakeCurrent(display, EGL10.EGL_NO_SURFACE,
+                    EGL10.EGL_NO_SURFACE,
+                    EGL10.EGL_NO_CONTEXT);
+                egl.eglDestroySurface(display, surface);
+                surface = null;
+            }
+            // Destroy main context
+            if (context != null) {
+                egl.eglDestroyContext(display, context);
+                context = null;
+            }
+            // Destroy GPU-worker EGL surface (if present)
+            if (gpuWorkerFakeSurface != null) {
+                egl.eglDestroySurface(display, gpuWorkerFakeSurface);
+                gpuWorkerFakeSurface = null;
+            }
+            // Destroy GPU-worker EGL context (if present)
+            if (gpuWorkerContext != null) {
+                egl.eglDestroyContext(display, gpuWorkerContext);
+                gpuWorkerContext = null;
+            }
+            // Remove EGL config
+            if (config != null) {
+                config = null;
+            }
+            // Terminate connection to EGL display
+            egl.eglTerminate(display);
+            display = null;
         }
     }
 }


### PR DESCRIPTION
Backport of #1114 to `r5.4`. Both commits cherry-picked unchanged — `MapRendererView.java` on this branch is byte-identical to the file on `master`.

**What it fixes**

- `releaseRendering()` / `stopRenderer()` waited on the EGL thread with no bound, and the thread held its own monitor for the whole operation, so a `wait(timeout)` could not have returned anyway. The operation now runs with the monitor released, and the teardown paths abandon the thread after `RELEASE_STOP_TIMEOUT`.
- `setupRenderer()` replaced the view's EGL thread without stopping it (the dev plugin's `recreateRenderer()` left one waiting forever on every call, EGL contexts alive).
- A view that handed its renderer over could still release it from `stopRenderer()`.
- An abandoned or stopped thread now destroys its own EGL resources before it exits.

**Measured**

Pixel 9 Pro XL, 20 s stall injected into `RELEASE_RENDERING`, app exit: `performDestroy` **20179 ms → 1567 ms**. Android Auto over DHU (connect / disconnect / rotation during projection / MSAA toggle, repeated): live `OpenGLThread` count stays at 1, no `DirectorException`, no NPE.

Compile-checked against the released `OsmAndCore_android-5.4.aar` (android-36).

**Not fixed by this**

The rotation/pause ANR itself. There main blocks in `GLSurfaceView.onPause()` on the frame in flight — `main → GLSurfaceView GLThread → EGL thread` — which is AOSP code reached before any of this. Play field stacks for that cluster show the stall inside `RENDER_FRAME` (Adreno shader linking in `initializeRasterLayersProgram`, and `GL_DrawElements` in `libGLESv2_samsung.so`), not on the edge bounded here.

Required by the app-side backport of osmandapp/OsmAnd#25936 — merge this first.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Explain why the two renderer PRs do not fix the rotation ANR, and why the wait cannot be bounded where it is.
2. Check the Play ANR cluster for 5.4 and for the last 28 days.
3. Advise what to move into 5.4.
4. Compose the 5.4 pull requests from the small, already-verified extracts.

Decided by the agent, not requested explicitly: cherry-picking both commits of #1114 rather than only the deadline one, because the app-side backport relies on the ownership guard from the second; verifying the result is byte-identical to `master` and compiling it against the released 5.4 AAR.
