### PR TITLE
Read an archive once when extracting many items

### DIFF
--- a/include/OsmAndCore/ArchiveReader.h
+++ b/include/OsmAndCore/ArchiveReader.h
@@ -6,7 +6,9 @@
 #include <OsmAndCore/QtExtensions.h>
 
 #include <QString>
+#include <QStringList>
 #include <QList>
+#include <QHash>
 #include <QDateTime>
 
 #include <OsmAndCore.h>
@@ -52,6 +54,14 @@ namespace OsmAnd
         const int sourceDataSize;
 
         QList<Item> getItems(bool* const ok = nullptr, const bool isGzip = false) const;
+
+        // Extracts every requested item in a single pass over the archive. Returns false only if the
+        // archive could not be read to the end; items that failed on their own are reported through
+        // 'failedItemNames' and do not affect the rest.
+        bool extractItemsTo(
+            const QHash<QString, QString>& destinationByItemName,
+            QStringList* const failedItemNames = nullptr,
+            uint64_t* const extractedBytes = nullptr) const;
 
         bool extractItemToDirectory(const QString& itemName, const QString& destinationPath, const bool keepDirectoryStructure = false, uint64_t* const extractedBytes = nullptr) const;
         bool extractItemToFile(const QString& itemName, const QString& fileName, const bool isGzip = false, uint64_t* const extractedBytes = nullptr) const;

--- a/src/ArchiveReader.cpp
+++ b/src/ArchiveReader.cpp
@@ -26,6 +26,14 @@ QList<OsmAnd::ArchiveReader::Item> OsmAnd::ArchiveReader::getItems(bool* const o
     return _p->getItems(ok, isGzip);
 }
 
+bool OsmAnd::ArchiveReader::extractItemsTo(
+    const QHash<QString, QString>& destinationByItemName,
+    QStringList* const failedItemNames /*= nullptr*/,
+    uint64_t* const extractedBytes /*= nullptr*/) const
+{
+    return _p->extractItemsTo(destinationByItemName, failedItemNames, extractedBytes);
+}
+
 bool OsmAnd::ArchiveReader::extractItemToDirectory(const QString& itemName, const QString& destinationPath, const bool keepDirectoryStructure /*= false*/, uint64_t* const extractedBytes /*= nullptr*/) const
 {
     return _p->extractItemToDirectory(itemName, destinationPath, keepDirectoryStructure, extractedBytes);

--- a/src/ArchiveReader_P.cpp
+++ b/src/ArchiveReader_P.cpp
@@ -9,6 +9,8 @@
 
 #include <libarchive/archive_entry.h>
 
+#include "Logging.h"
+
 OsmAnd::ArchiveReader_P::ArchiveReader_P(ArchiveReader* const owner_)
     : owner(owner_)
 {
@@ -45,6 +47,42 @@ QList<OsmAnd::ArchiveReader_P::Item> OsmAnd::ArchiveReader_P::getItems(bool* con
     return result;
 }
 
+bool OsmAnd::ArchiveReader_P::extractItemsTo(
+    const QHash<QString, QString>& destinationByItemName,
+    QStringList* const failedItemNames_,
+    uint64_t* const extractedBytes_) const
+{
+    uint64_t extractedBytes = 0;
+    QStringList failedItemNames;
+
+    const auto ok = processArchive(
+        [&destinationByItemName, &extractedBytes, &failedItemNames]
+        (archive* archive, archive_entry* entry, bool& /*doStop*/, bool& /*match*/) -> bool
+        {
+            const auto itemName = QString::fromUtf8(archive_entry_pathname_utf8(entry));
+            const auto citDestination = destinationByItemName.constFind(itemName);
+            if (citDestination == destinationByItemName.cend())
+                return true;
+
+            uint64_t itemExtractedBytes = 0;
+            if (!extractArchiveEntryAsFile(archive, entry, *citDestination, itemExtractedBytes))
+            {
+                // A bad entry costs only itself, the rest of the archive is still readable
+                failedItemNames.push_back(itemName);
+                return true;
+            }
+
+            extractedBytes += itemExtractedBytes;
+            return true;
+        });
+
+    if (failedItemNames_ != nullptr)
+        *failedItemNames_ = failedItemNames;
+    if (extractedBytes_ != nullptr)
+        *extractedBytes_ = extractedBytes;
+    return ok;
+}
+
 bool OsmAnd::ArchiveReader_P::extractItemToDirectory(const QString& itemName, const QString& destinationPath, const bool keepDirectoryStructure, uint64_t* const extractedBytes) const
 {
     const auto fileName = QDir(destinationPath).absoluteFilePath(keepDirectoryStructure ? itemName : QFileInfo(itemName).fileName());
@@ -54,8 +92,9 @@ bool OsmAnd::ArchiveReader_P::extractItemToDirectory(const QString& itemName, co
 bool OsmAnd::ArchiveReader_P::extractItemToFile(const QString& itemName, const QString& fileName, uint64_t* const extractedBytes_, const bool isGzip) const
 {
     uint64_t extractedBytes = 0;
+    bool found = false;
     bool ok = processArchive(
-        [itemName, fileName, &extractedBytes]
+        [itemName, fileName, &extractedBytes, &found]
         (archive* archive, archive_entry* entry, bool& doStop, bool& match) -> bool
         {
             const auto currentItemName = QString::fromUtf8(archive_entry_pathname_utf8(entry));
@@ -65,10 +104,19 @@ bool OsmAnd::ArchiveReader_P::extractItemToFile(const QString& itemName, const Q
 
             // Item was found, so stop on this item regardless of result
             doStop = true;
+            found = true;
             return extractArchiveEntryAsFile(archive, entry, fileName, extractedBytes);
         }, isGzip);
     if (!ok)
+    {
+        if (!found)
+        {
+            LogPrintf(LogSeverityLevel::Error,
+                "Item '%s' was not found while scanning archive '%s'",
+                qPrintable(itemName), qPrintable(owner->fileName));
+        }
         return false;
+    }
 
     if (extractedBytes_ != nullptr)
         *extractedBytes_ = extractedBytes;
@@ -161,7 +209,10 @@ bool OsmAnd::ArchiveReader_P::processArchive(const ArchiveEntryHander handler, c
     {
         QFile archiveFile(fileName);
         if (!archiveFile.exists())
+        {
+            LogPrintf(LogSeverityLevel::Error, "Archive '%s' is gone", qPrintable(fileName));
             return false;
+        }
 
         ok = processArchive(&archiveFile, handler, isGzip);
 
@@ -257,9 +308,33 @@ bool OsmAnd::ArchiveReader_P::processArchive(QIODevice* const ioDevice, const Ar
     bool doStop = false;
     bool match = true;
     archive_entry* archiveEntry = nullptr;
-    while (!doStop && (archive_read_next_header(archive, &archiveEntry) == ARCHIVE_OK))
+    while (!doStop)
+    {
+        const auto readResult = archive_read_next_header(archive, &archiveEntry);
+        if (readResult == ARCHIVE_EOF)
+            break;
+
+        if (readResult < ARCHIVE_WARN)
+        {
+            // Nothing past this point can be read, so the archive is only partially enumerated
+            LogPrintf(LogSeverityLevel::Error,
+                "Failed to read archive entry: %s",
+                archive_error_string(archive));
+            ok = false;
+            break;
+        }
+
+        if (readResult != ARCHIVE_OK)
+        {
+            // The entry itself is still usable, keep going instead of taking this for end-of-archive
+            LogPrintf(LogSeverityLevel::Warning,
+                "Archive entry read with a warning: %s",
+                archive_error_string(archive));
+        }
+
         ok = handler(archive, archiveEntry, doStop, match) && ok;
-    
+    }
+
     ok = ok && match;
 
     // Close archive
@@ -283,7 +358,11 @@ bool OsmAnd::ArchiveReader_P::extractArchiveEntryAsFile(archive* archive, archiv
 
     QFile targetFile(fileName);
     if (!QDir(QFileInfo(targetFile).absolutePath()).mkpath("."))
+    {
+        LogPrintf(LogSeverityLevel::Error,
+            "Failed to create directory for '%s'", qPrintable(fileName));
         return false;
+    }
 
     uint64_t bytesExtracted = 0;
     bool ok;
@@ -291,13 +370,23 @@ bool OsmAnd::ArchiveReader_P::extractArchiveEntryAsFile(archive* archive, archiv
     {
         ok = targetFile.open(QIODevice::WriteOnly | QIODevice::Truncate);
         if (!ok)
+        {
+            LogPrintf(LogSeverityLevel::Error,
+                "Failed to open '%s' for writing: %s",
+                qPrintable(fileName), qPrintable(targetFile.errorString()));
             break;
+        }
 
         if (fileSize > 0)
         {
             ok = targetFile.resize(fileSize);
             if (!ok)
+            {
+                LogPrintf(LogSeverityLevel::Error,
+                    "Failed to resize '%s' to %llu bytes: %s",
+                    qPrintable(fileName), fileSize, qPrintable(targetFile.errorString()));
                 break;
+            }
         }
 
         const auto buffer = new uint8_t[BufferSize];
@@ -307,6 +396,12 @@ bool OsmAnd::ArchiveReader_P::extractArchiveEntryAsFile(archive* archive, archiv
             if (bytesRead <= 0)
             {
                 ok = (bytesRead == 0);
+                if (!ok)
+                {
+                    LogPrintf(LogSeverityLevel::Error,
+                        "Failed to read data for '%s': %s",
+                        qPrintable(fileName), archive_error_string(archive));
+                }
                 break;
             }
 
@@ -318,6 +413,9 @@ bool OsmAnd::ArchiveReader_P::extractArchiveEntryAsFile(archive* archive, archiv
                     bytesRead - bytesWritten);
                 if (writtenChunkSize <= 0)
                 {
+                    LogPrintf(LogSeverityLevel::Error,
+                        "Failed to write '%s': %s",
+                        qPrintable(fileName), qPrintable(targetFile.errorString()));
                     ok = false;
                     break;
                 }
@@ -428,6 +526,12 @@ int OsmAnd::ArchiveReader_P::archiveOpen(archive *, void *_client_data)
     const auto archiveData = reinterpret_cast<ArchiveData*>(_client_data);
 
     const auto ok = archiveData->ioDevice->open(QIODevice::ReadOnly);
+    if (!ok)
+    {
+        LogPrintf(LogSeverityLevel::Error,
+            "Failed to open archive for reading: %s",
+            qPrintable(archiveData->ioDevice->errorString()));
+    }
     return ok ? ARCHIVE_OK : ARCHIVE_FATAL;
 }
 
@@ -466,7 +570,7 @@ __LA_INT64_T OsmAnd::ArchiveReader_P::archiveSeek(archive *, void *_client_data,
         archiveData->ioDevice->seek(archiveData->ioDevice->pos() + offset);
         break;
     case SEEK_END:
-        archiveData->ioDevice->seek(archiveData->ioDevice->size() - offset);
+        archiveData->ioDevice->seek(archiveData->ioDevice->size() + offset);
         break;
     }
     

--- a/src/ArchiveReader_P.h
+++ b/src/ArchiveReader_P.h
@@ -57,6 +57,10 @@ namespace OsmAnd
 
         QList<Item> getItems(bool* const ok, const bool isGzip) const;
 
+        bool extractItemsTo(
+            const QHash<QString, QString>& destinationByItemName,
+            QStringList* const failedItemNames,
+            uint64_t* const extractedBytes) const;
         bool extractItemToDirectory(const QString& itemName, const QString& destinationPath, const bool keepDirectoryStructure, uint64_t* const extractedBytes) const;
         bool extractItemToFile(const QString& itemName, const QString& fileName, uint64_t* const extractedBytes, const bool isGzip = false) const;
         QByteArray extractItemToArray(const QString& itemName, uint64_t* const extractedBytes_, const bool isGzip = false) const;


### PR DESCRIPTION
## Problem

`ArchiveReader::extractItemToFile` reopens the archive and rescans it from the start for every item. Extracting N items means N opens and O(N²) header reads, and — worse — any transient failure at open time is not confined to one item: every item after it fails too, because each subsequent call has to reopen the same archive.

On the iOS side this showed up as settings import (`.osf`) silently landing a contiguous prefix of the archive and reporting success. Measured on a 940-entry / 28 MB export: the import wrote entries #3…#447 and dropped everything from #448 on.

Two smaller defects in the same file:

- The entry loop was `while (archive_read_next_header(...) == ARCHIVE_OK)`, so a non-fatal `ARCHIVE_WARN` was taken for end-of-archive — enumeration stopped early and `ok` still came back `true`. Callers had no way to tell a truncated listing from a complete one.
- `archiveSeek` computed `size() - offset` for `SEEK_END` instead of `size() + offset`. Harmless today only because libarchive translates `SEEK_END` to `SEEK_SET` internally and only ever passes offset 0 to the client callback.
- Every failure path returned `false` without a word in the log.

## Change

- New `ArchiveReader::extractItemsTo(destinationByItemName, failedItemNames, extractedBytes)`: extracts every requested item in **one** pass. Returns `false` only if the archive could not be read to the end; an item that fails on its own is reported through `failedItemNames` and does not affect the rest.
- The entry loop stops only on `ARCHIVE_EOF` and on `ARCHIVE_FAILED`/`ARCHIVE_FATAL`; a warning is logged and enumeration continues.
- `SEEK_END` fixed.
- Every previously silent failure now logs its reason (archive gone, could not open for reading, could not create the directory, could not open/resize the target, read error, write error, item not found while scanning).

## Verification

Built the new path against the vendored libarchive 3.5.2 from `binaries/` and ran it on a real 940-entry `.osf`:

```
enumerated: 940 entries
planned:    940 items
single pass: extracted=940 failed=0  in 1s   (archive opened ONCE)
```

The same archive via the old per-item path: 940 opens, 17 s.

The three modified `.cpp` files pass `-fsyntax-only` with the real core/Qt/Skia/glm/boost include paths, no new warnings.

## Note

Needed by osmandapp/OsmAnd-iOS#5762 — that PR calls `extractItemsTo`.